### PR TITLE
Add ability to set num of jobs for make + extra error checks

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -372,11 +372,13 @@ if [ "${PORT_GIT}x" != "x" ]; then
     printError "PORT_URL or PORT_GIT_URL needs to be defined to the root directory of the tool being ported"
   fi
   if [ "${PORT_GIT_DEPS}x" = "x" ]; then
-    printError "PORT_DEPS or PORT_GIT_DEPS needs to be defined to the ported tools this depends on"
+    #printError "PORT_DEPS or PORT_GIT_DEPS needs to be defined to the ported tools this depends on"
   fi
   export GIT_SSL_CAINFO="${ca}"
   deps="${PORT_GIT_DEPS}"
 fi
+
+checkdeps ${deps}
 
 #
 # For the compilers and corresponding flags, you need to either specify both the compiler and flag, or neither
@@ -416,19 +418,15 @@ cd "${PORT_ROOT}" || exit 99
 
 if [ "${PORT_GIT}x" != "x" ]; then
   echo "Checking if git directory already cloned"
-  dir=$(gitclone)
-  rc=$?
-  if [ $rc -gt 0 ]; then
-    exit $rc;
+  if ! dir=$(gitclone) ; then 
+    exit 4
   fi
 fi
 
 if [ "${PORT_TARBALL}x" != "x" ]; then
   echo "Checking if tarball already downloaded"
-  dir=$(downloadtarball)
-  rc=$?
-  if [ $rc -gt 0 ]; then
-    exit $rc;
+  if ! dir=$(downloadtarball) ; then 
+    exit 4
   fi
 fi
 PROD_DIR="${HOME}/zot/prod/${dir}"

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -166,7 +166,7 @@ extracttarball()
   fi
 
   files=$(find . ! -name "*.pdf" ! -name "*.png" ! -type d)
-  if ! git init . >$STDERR || ! git add ${files} >$STDERR || ! git commit --allow-empty -m "Create Repository for patch management" >$STDERR; then
+  if ! git init . >$STDERR || ! git add -f ${files} >$STDERR || ! git commit --allow-empty -m "Create Repository for patch management" >$STDERR; then
     printError "Unable to initialize git repository for tarball"
   fi
   # Having the directory git-managed exposes some problems in the current git for software like autoconf,

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -80,7 +80,7 @@ setdepsenv()
     elif [ -r "${HOME}/zot/boot/${dep}/.env" ]; then
       depdir="${HOME}/zot/boot/${dep}"
     else
-      printError "Internal error. Unable to find .env but earlier check should have caught this"
+      printError "Internal error. Unable to find .env for ${deps} but earlier check should have caught this"
     fi
     printVerbose "Setting up environment for: ${depdir}"
     cd ${depdir} && . ./.env

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -417,11 +417,19 @@ cd "${PORT_ROOT}" || exit 99
 if [ "${PORT_GIT}x" != "x" ]; then
   echo "Checking if git directory already cloned"
   dir=$(gitclone)
+  rc=$?
+  if [ $rc -gt 0 ]; then
+    exit $rc;
+  fi
 fi
 
 if [ "${PORT_TARBALL}x" != "x" ]; then
   echo "Checking if tarball already downloaded"
   dir=$(downloadtarball)
+  rc=$?
+  if [ $rc -gt 0 ]; then
+    exit $rc;
+  fi
 fi
 PROD_DIR="${HOME}/zot/prod/${dir}"
 

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -372,7 +372,7 @@ if [ "${PORT_GIT}x" != "x" ]; then
     printError "PORT_URL or PORT_GIT_URL needs to be defined to the root directory of the tool being ported"
   fi
   if [ "${PORT_GIT_DEPS}x" = "x" ]; then
-    #printError "PORT_DEPS or PORT_GIT_DEPS needs to be defined to the ported tools this depends on"
+    printError "PORT_DEPS or PORT_GIT_DEPS needs to be defined to the ported tools this depends on"
   fi
   export GIT_SSL_CAINFO="${ca}"
   deps="${PORT_GIT_DEPS}"

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -279,6 +279,11 @@ myparentdir=$(
   echo $PWD
 )
 
+mydir=$(
+  cd $(dirname $0)/
+  echo $PWD
+)
+
 set +x
 if [ "$1" = "-v" ]; then
   verbose=true
@@ -420,6 +425,18 @@ if [ "${PORT_TARBALL}x" != "x" ]; then
 fi
 PROD_DIR="${HOME}/zot/prod/${dir}"
 
+
+if [ "${PORT_NUM_JOBS}x" = "x" ]; then
+  PORT_NUM_JOBS=$("${mydir}/numcpus.rexx")
+
+  # Use half of the CPUs by default
+  export PORT_NUM_JOBS=$((PORT_NUM_JOBS / 2))
+fi
+
+if [ $PORT_NUM_JOBS -lt 1 ]; then
+  export PORT_NUM_JOBS=1
+fi
+
 if [ "${PORT_BOOTSTRAP}x" = "x" ]; then
   export PORT_BOOTSTRAP="./bootstrap"
 fi
@@ -436,7 +453,7 @@ if [ "${PORT_MAKE}x" = "x" ]; then
   export PORT_MAKE=$(whence make)
 fi
 if [ "${PORT_MAKE_OPTS}x" = "x" ]; then
-  export PORT_MAKE_OPTS=""
+  export PORT_MAKE_OPTS="-j${PORT_NUM_JOBS}"
 fi
 if [ "${PORT_CHECK}x" = "x" ]; then
   export PORT_CHECK=$(whence make)

--- a/bin/numcpus.rexx
+++ b/bin/numcpus.rexx
@@ -1,0 +1,3 @@
+/* REXX */
+x = SYSCPUS('CPUS.')
+say CPUS.0


### PR DESCRIPTION
* Sets the default to numcpus/2
* Perl builds slowly on real hardware otherwise
* Developer can set PORT_NUM_JOBS in setenv.sh to override default
* Added extra error checks