### PR TITLE
Customize installation for Jenkins

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -713,7 +713,6 @@ if [ "${PORT_CONFIGURE_OPTS}x" = "x" ]; then
 	export PORT_CONFIGURE_OPTS="--prefix=${PORT_INSTALL_DIR}"
 fi
 
-
 if ! applyPatches; then
   exit 4
 fi


### PR DESCRIPTION
* PORT_PACKAGE_INSTALL introduced to pax the install location into a pax.Z
* Allow overriding of install dir with PORT_INSTALL_DIR
* Allow PORT_NAME to be set (used in pax filename), uses git/tar name as default