### PR TITLE
Fix make check + log

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -330,7 +330,7 @@ setEnv()
   setDepsEnv
 
   if [ "${PORT_NUM_JOBS}x" = "x" ]; then
-    PORT_NUM_JOBS=$(${utildir}/numcpus.rexx)
+    PORT_NUM_JOBS=$("${utildir}/numcpus.rexx")
 
     # Use half of the CPUs by default
     export PORT_NUM_JOBS=$((PORT_NUM_JOBS / 2))

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -659,7 +659,7 @@ install()
     fi
 
     paxFileName="${PORT_NAME}.${LOG_PFX}.zos.pax.Z";
-    if ! runAndLog "pax -w -z -x pax -f \"${paxFileName}\" \"${PORT_INSTALL_DIR}/\""; then
+    if ! runAndLog "pax -w -z -x pax \"-s#${PORT_INSTALL_DIR}/#${PORT_NAME}.${LOG_PFX}.zos/#\" -f \"${paxFileName}\" \"${PORT_INSTALL_DIR}/\""; then
       printError "Could not generate pax \"${paxFileName}\""
     fi
   else 

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -330,13 +330,10 @@ setEnv()
   setDepsEnv
 
   if [ "${PORT_NUM_JOBS}x" = "x" ]; then
-    numcpus="${utildir}/numcpus.rexx"
-    if [ -x ${numcpus} ]; then
-      PORT_NUM_JOBS=$(${numcpus})
+    PORT_NUM_JOBS=$(${utildir}/numcpus.rexx)
 
-      # Use half of the CPUs by default
-      export PORT_NUM_JOBS=$((PORT_NUM_JOBS / 2))
-    fi
+    # Use half of the CPUs by default
+    export PORT_NUM_JOBS=$((PORT_NUM_JOBS / 2))
   fi
 
   if [ $PORT_NUM_JOBS -lt 1 ]; then
@@ -674,10 +671,8 @@ install()
 # Start of 'main'
 #
 
-utildir=$( cd $(dirname "$0")/ || exit; echo $PWD)
-export utildir
-utilparentdir=$( cd $(dirname "$0")/../ || exit; echo $PWD)
-export utilparentdir
+export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
+export utilparentdir="$( cd "$(dirname "$0")/../" >/dev/null 2>&1 && pwd -P )"
 
 set +x 
 

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -393,7 +393,7 @@ gitClone()
     printInfo "Using existing git clone'd directory ${dir}" 
   else
     printInfo "Clone and create ${dir}" 
-    if ! git clone "${PORT_GIT_URL}" 2>/dev/null; then
+    if ! runAndLog "git clone \"${PORT_GIT_URL}\""; then
       printError "Unable to clone ${gitname} from ${PORT_GIT_URL}"
     fi
     if [ "${PORT_GIT_BRANCH}x" != "x" ]; then

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -444,8 +444,10 @@ extractTarBall()
     printError "Unable to create .gitattributes for tarball"
   fi
 
-  if ! iconv -f IBM-1047 -tISO8859-1 <.gitattributes >.gitattrascii || ! chtag -tcISO8859-1 .gitattrascii || ! mv .gitattrascii .gitattributes; then
-    printError "Unable to make .gitattributes ascii for tarball"
+  if [ "$(chtag -p .gitattributes | cut -f2 -d' ')" != "ISO8859-1" ]; then
+    if ! iconv -f IBM-1047 -tISO8859-1 <.gitattributes >.gitattrascii || ! chtag -tcISO8859-1 .gitattrascii || ! mv .gitattrascii .gitattributes; then
+      printError "Unable to make .gitattributes ascii for tarball"
+    fi
   fi
 
   files=$(find . ! -name "*.pdf" ! -name "*.png" ! -name "*.bat" ! -type d)

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -185,7 +185,7 @@ checkDeps()
     fi
   done
   if $fail ; then
-    #return 4
+    return 4
   fi
 }
 
@@ -292,7 +292,7 @@ setDepsEnv()
     elif [ -r "${HOME}/zot/boot/${dep}/.env" ]; then
       depdir="${HOME}/zot/boot/${dep}"
     else
-      #printError "Internal error. Unable to find .env for ${deps} but earlier check should have caught this"
+      printError "Internal error. Unable to find .env for ${deps} but earlier check should have caught this"
     fi
     printVerbose "Setting up ${depdir} dependency environment"
     cd "${depdir}" && . ./.env

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -330,10 +330,13 @@ setEnv()
   setDepsEnv
 
   if [ "${PORT_NUM_JOBS}x" = "x" ]; then
-    PORT_NUM_JOBS=$("${utildir}/numcpus.rexx")
+    numcpus="${utildir}/numcpus.rexx"
+    if [ -x ${numcpus} ]; then
+      PORT_NUM_JOBS=$(${numcpus})
 
-    # Use half of the CPUs by default
-    export PORT_NUM_JOBS=$((PORT_NUM_JOBS / 2))
+      # Use half of the CPUs by default
+      export PORT_NUM_JOBS=$((PORT_NUM_JOBS / 2))
+    fi
   fi
 
   if [ $PORT_NUM_JOBS -lt 1 ]; then

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -185,7 +185,7 @@ checkDeps()
     fi
   done
   if $fail ; then
-    return 4
+    #return 4
   fi
 }
 
@@ -292,7 +292,7 @@ setDepsEnv()
     elif [ -r "${HOME}/zot/boot/${dep}/.env" ]; then
       depdir="${HOME}/zot/boot/${dep}"
     else
-      printError "Internal error. Unable to find .env for ${deps} but earlier check should have caught this"
+      #printError "Internal error. Unable to find .env for ${deps} but earlier check should have caught this"
     fi
     printVerbose "Setting up ${depdir} dependency environment"
     cd "${depdir}" && . ./.env
@@ -631,6 +631,7 @@ check()
   checklog="${LOG_PFX}_check.log"
   if [ "${PORT_CHECK}x" != "skipx" ] ; then
     printHeader "Running Check"
+    runAndLog "\"${PORT_CHECK}\" ${PORT_CHECK_OPTS} >\"${checklog}\""
     if ! runAndLog "\"${PORT_CHECK_RESULTS}\" \"${PORT_ROOT}/${dir}\" \"${LOG_PFX}\""; then
       printError "Check failed. Log: ${checklog}"
     fi


### PR DESCRIPTION
* Adds the make check step back
* logs the git clone in case of error
* avoids converting/tagging .gitattributes if already tagged (affecting git 2.26)