### PR TITLE
WIP: download script for github releases

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -51,6 +51,11 @@ PORT_INSTALL_OPTS   Options to pass to installation program (defaults to '${PORT
 
 }
 
+export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
+export utilparentdir="$( cd "$(dirname "$0")/../" >/dev/null 2>&1 && pwd -P )"
+
+. "${utildir}/common.inc"
+
 setDefaults()
 {
 	export PORT_CCD="xlclang"
@@ -111,68 +116,6 @@ processOptions()
         ;;
     esac
   done
-}
-
-defineColors() 
-{
-  if [ ! "${_BPX_TERMPATH-x}" = "OMVS" ] && [ -z "${NO_COLOR}" ] && [ ! "${FORCE_COLOR-x}" = "0" ]; then
-    esc="\047"
-    RED="${esc}[31m"
-    GREEN="${esc}[32m"
-    YELLOW="${esc}[33m"
-    BOLD="${esc}[1m"
-    UNDERLINE="${esc}[4m"
-    NC="${esc}[0m"
-  else
-#    unset esc RED GREEN YELLOW BOLD UNDERLINE NC
-
-    esc=''
-    RED=''
-    GREEN=''
-    YELLOW=''
-    BOLD=''
-    UNDERLINE=''
-    NC=''
-  fi
-}
-
-printVerbose()
-{
-  if ${verbose}; then
-    printf "${NC}${GREEN}${BOLD}VERBOSE${NC}: '${1}'\n" >&2
-  fi
-}
-
-printHeader()
-{
-  printf "${NC}${UNDERLINE}${1}...${NC}\n" >&2
-}
-
-runAndLog()
-{
-  printVerbose "$1"
-  eval "$1"
-}
-
-printSoftError()
-{
-  printf "${NC}${RED}${BOLD}***ERROR: ${NC}${RED}${1}${NC}\n" >&2
-}
-
-printError()
-{
-  printSoftError "${1}"
-  exit 4
-}
-
-printWarning()
-{
-  printf "${NC}${YELLOW}${BOLD}***WARNING: ${NC}${YELLOW}${1}${NC}\n" >&2
-}
-
-printInfo()
-{
-  printf "$1\n" >&2
 }
 
 checkDeps()
@@ -709,9 +652,6 @@ install()
 #
 # Start of 'main'
 #
-
-export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
-export utilparentdir="$( cd "$(dirname "$0")/../" >/dev/null 2>&1 && pwd -P )"
 
 set +x 
 

--- a/bin/common.inc
+++ b/bin/common.inc
@@ -1,0 +1,62 @@
+#!/bin/sh
+defineColors() 
+{
+  if [ ! "${_BPX_TERMPATH-x}" = "OMVS" ] && [ -z "${NO_COLOR}" ] && [ ! "${FORCE_COLOR-x}" = "0" ]; then
+    esc="\047"
+    RED="${esc}[31m"
+    GREEN="${esc}[32m"
+    YELLOW="${esc}[33m"
+    BOLD="${esc}[1m"
+    UNDERLINE="${esc}[4m"
+    NC="${esc}[0m"
+  else
+#    unset esc RED GREEN YELLOW BOLD UNDERLINE NC
+
+    esc=''
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BOLD=''
+    UNDERLINE=''
+    NC=''
+  fi
+}
+
+printVerbose()
+{
+  if ${verbose}; then
+    printf "${NC}${GREEN}${BOLD}VERBOSE${NC}: '${1}'\n" >&2
+  fi
+}
+
+printHeader()
+{
+  printf "${NC}${UNDERLINE}${1}...${NC}\n" >&2
+}
+
+runAndLog()
+{
+  printVerbose "$1"
+  eval "$1"
+}
+
+printSoftError()
+{
+  printf "${NC}${RED}${BOLD}***ERROR: ${NC}${RED}${1}${NC}\n" >&2
+}
+
+printError()
+{
+  printSoftError "${1}"
+  exit 4
+}
+
+printWarning()
+{
+  printf "${NC}${YELLOW}${BOLD}***WARNING: ${NC}${YELLOW}${1}${NC}\n" >&2
+}
+
+printInfo()
+{
+  printf "$1\n" >&2
+}

--- a/bin/downloadports
+++ b/bin/downloadports
@@ -1,20 +1,22 @@
-#!/bin/bash
-#
-# Downloads and extracts the latest ported releases from GitHub
+#!/bin/sh
+# Downloads and extracts the latest ZOSOpenTools releases from GitHub
 
-printSoftError()
+export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
+
+. "${utildir}/common.inc"
+
+printSyntax() 
 {
-  printf "${NC}${RED}${BOLD}***ERROR: ${NC}${RED}${1}${NC}\n" >&2
+  args=$*
+  echo "downloadports is a tool that downloads and extracts the latest z/OS Open Tools releases from GitHub Releases." >&2
+  echo "Syntax: downloadports [<option>]*" >&2
+  echo "  where <option> may be one or more of:" >&2
+  echo "  -d: print this information" >&2
+  echo "  -t: run in verbose mode" >&2
 }
 
-printError()
-{
-  printSoftError "${1}"
-  exit 4
-}
-
+args=$*
 while [[ $# -gt 0 ]]; do
-  #TODO: add support to download specific ports
   case "$1" in
     "-d")
       download=$2;
@@ -24,35 +26,64 @@ while [[ $# -gt 0 ]]; do
       toolrepo=$2;
       shift
       ;;
+    "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
+      printSyntax "${args}"
+      exit 4
+      ;;
     *)
-      printError "Unknown option ${1} specified"
+      printError "Unknown option ${arg} specified"
       ;;
   esac
   shift;
 done
 
 if [ ! -z ${download} -a -d ${download} ]; then
-  pushd ${download}
+  cd ${download}
 fi
 
 #FIXME: Once jq is ported, rewrite with jq
-for repo in $(curl -s "https://api.github.com/users/ZOSOpenTools/repos?per_page=100" | grep "\"full_name\":" | cut -d '"' -f 4); do
-  repo=${repo#"ZOSOpenTools/"}
+if ! repo_results=$(curl -s "https://api.github.com/users/ZOSOpenTools/repos?per_page=100" 2>/dev/null | grep "\"full_name\":" | cut -d '"' -f 4); then
+  printError "curl command could not download the z/OS Open Tools repository list"
+fi
+
+for repo in $(echo ${repo_results}); do
   echo $repo
+  repo=${repo#"ZOSOpenTools/"}
   if [ -z "${toolrepo}" -o "${toolrepo}" == "${repo}" ]; then
+    printHeader "Downloading latest release from $repo"
     URL=$(curl -s https://api.github.com/repos/ZOSOpenTools/${repo}/releases/latest | grep browser_download_url | cut -d '"' -f 4)
-    if [ "${URL}" == "" ]; then
-      continue;
+    if ! latest_url=$(curl -s https://api.github.com/repos/ZOSOpenTools/${repo}/releases/latest 2>/dev/null | grep browser_download_url | cut -d '"' -f 4); then
+      printError "Could not find the latest url for $repo"
     fi
-    curl -L ${URL} -O
-    pax=$(basename ${URL})
-    pax -rf $pax
+
+    if [ "${latest_url}" == "" ]; then
+      printWarning "No releases published for $repo"
+      continue
+    fi
+
+    if ! curl -L ${latest_url} -O 2>/dev/null; then
+      printError "Could not download ${latest_url}"
+    fi
+
+    pax=$(basename ${latest_url})
+    if [ ! -f "${pax}" ]; then
+      printError "${pax} was not actually downloaded?"
+    fi
+
+    printHeader "Extracting $pax"
+    if ! pax -rf $pax 2>/dev/null; then
+      printError "Could not extract $pax"
+    fi
+    rm -f "${pax}"
     dirname=${pax%.pax.Z}
     name=${repo%port}
-    ln -s $dirname $name
+    if [ -L $name ]; then
+      rm $name
+    fi 
+    if ! ln -s $dirname $name; then
+      printError "Could not create symbolic link name"
+    fi 
+  else
+    printHeader "Skipping download of latest release from $repo"
   fi
 done
-
-if [ ! -z ${download} -a -d ${download} ]; then
-  popd
-fi

--- a/bin/downloadports
+++ b/bin/downloadports
@@ -39,7 +39,7 @@ fi
 for repo in $(curl -s "https://api.github.com/users/ZOSOpenTools/repos?per_page=100" | grep "\"full_name\":" | cut -d '"' -f 4); do
   repo=${repo#"ZOSOpenTools/"}
   echo $repo
-  if [ ! -z "${toolrepo}" -a "${toolrepo}" == "${repo}" ]; then
+  if [ -z "${toolrepo}" -o "${toolrepo}" == "${repo}" ]; then
     URL=$(curl -s https://api.github.com/repos/ZOSOpenTools/${repo}/releases/latest | grep browser_download_url | cut -d '"' -f 4)
     if [ "${URL}" == "" ]; then
       continue;
@@ -47,6 +47,9 @@ for repo in $(curl -s "https://api.github.com/users/ZOSOpenTools/repos?per_page=
     curl -L ${URL} -O
     pax=$(basename ${URL})
     pax -rf $pax
+    dirname=${pax%.pax.Z}
+    name=${repo%port}
+    ln -s $dirname $name
   fi
 done
 

--- a/bin/downloadports
+++ b/bin/downloadports
@@ -51,7 +51,6 @@ for repo in $(echo ${repo_results}); do
   repo=${repo#"ZOSOpenTools/"}
   if [ -z "${toolrepo}" -o "${toolrepo}" == "${repo}" ]; then
     printHeader "Downloading latest release from $repo"
-    URL=$(curl -s https://api.github.com/repos/ZOSOpenTools/${repo}/releases/latest | grep browser_download_url | cut -d '"' -f 4)
     if ! latest_url=$(curl -s https://api.github.com/repos/ZOSOpenTools/${repo}/releases/latest 2>/dev/null | grep browser_download_url | cut -d '"' -f 4); then
       printError "Could not find the latest url for $repo"
     fi

--- a/bin/downloadports
+++ b/bin/downloadports
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Downloads the latest ported release from GitHub
+
+printSoftError()
+{
+  printf "${NC}${RED}${BOLD}***ERROR: ${NC}${RED}${1}${NC}\n" >&2
+}
+
+printError()
+{
+  printSoftError "${1}"
+  exit 4
+}
+
+while [[ $# -gt 0 ]]; do
+  #TODO: add support to download specific ports
+  case "$1" in
+    "-d")
+      download=$2;
+      shift
+      ;;
+    "-t")
+      toolrepo=$2;
+      shift
+      ;;
+    *)
+      printError "Unknown option ${arg} specified"
+      ;;
+  esac
+  shift;
+done
+
+if [ ! -z ${download} -a -d ${download} ]; then
+  pushd ${download}
+fi
+exit 0
+
+#FIXME: Once jq is ported, rewrite with jq
+for repo in $(curl -s "https://api.github.com/users/ZOSOpenTools/repos?per_page=100" | grep "\"name\":" | cut -d '"' -f 4); do
+  echo $repo
+  if [ ! -z "${toolrepo}" -a "${toolrepo}" == "${repo}" ]; then
+    URL=$(curl -s https://api.github.com/repos/ZOSOpenTools/${repo}/releases/latest | grep browser_download_url | cut -d '"' -f 4)
+    if [ "${URL}" == "" ]; then
+      continue;
+    fi
+    curl -L ${URL} -O
+  fi
+done
+
+if [ ! -z ${download} -a -d ${download} ]; do
+  popd ${download}
+done

--- a/bin/downloadports
+++ b/bin/downloadports
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Downloads the latest ported release from GitHub
+# Downloads and extracts the latest ported releases from GitHub
 
 printSoftError()
 {
@@ -25,7 +25,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     *)
-      printError "Unknown option ${arg} specified"
+      printError "Unknown option ${1} specified"
       ;;
   esac
   shift;
@@ -34,10 +34,10 @@ done
 if [ ! -z ${download} -a -d ${download} ]; then
   pushd ${download}
 fi
-exit 0
 
 #FIXME: Once jq is ported, rewrite with jq
-for repo in $(curl -s "https://api.github.com/users/ZOSOpenTools/repos?per_page=100" | grep "\"name\":" | cut -d '"' -f 4); do
+for repo in $(curl -s "https://api.github.com/users/ZOSOpenTools/repos?per_page=100" | grep "\"full_name\":" | cut -d '"' -f 4); do
+  repo=${repo#"ZOSOpenTools/"}
   echo $repo
   if [ ! -z "${toolrepo}" -a "${toolrepo}" == "${repo}" ]; then
     URL=$(curl -s https://api.github.com/repos/ZOSOpenTools/${repo}/releases/latest | grep browser_download_url | cut -d '"' -f 4)
@@ -45,9 +45,11 @@ for repo in $(curl -s "https://api.github.com/users/ZOSOpenTools/repos?per_page=
       continue;
     fi
     curl -L ${URL} -O
+    pax=$(basename ${URL})
+    pax -rf $pax
   fi
 done
 
-if [ ! -z ${download} -a -d ${download} ]; do
-  popd ${download}
-done
+if [ ! -z ${download} -a -d ${download} ]; then
+  popd
+fi

--- a/bin/downloadports
+++ b/bin/downloadports
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Downloads and extracts the latest ZOSOpenTools releases from GitHub
 
 export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"

--- a/bin/importenvs
+++ b/bin/importenvs
@@ -8,11 +8,11 @@ if [ ! -d "${HOME}/zot/boot/" ]; then
   exit 4;
 fi
 
-for deps in $(find "${HOME}/zot/boot/" -name "*.env")
+for deps in $(find "${HOME}/zot/boot/" -name ".env")
 do
   echo "Found ${deps}"
   depdir=$(dirname "${deps}")
-  pushd $depdir
+  cd $depdir
   . ./.env
-  popd
+  cd -
 done

--- a/bin/importenvs
+++ b/bin/importenvs
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# Used for development to source all the boot .envs
+# . importenvs
+
+if [ ! -d "${HOME}/zot/boot/" ]; then
+  echo "boot directory does not exist.  Existing"
+  exit 4;
+fi
+
+for deps in $(find "${HOME}/zot/boot/" -name "*.env")
+do
+  echo "Found ${deps}"
+  depdir=$(dirname "${deps}")
+  pushd $depdir
+  . ./.env
+  popd
+done


### PR DESCRIPTION
* Adds initial version of downloadports, which downloads the latest releases from Github and extracts to $PWD (by default) or a directory as specified by -d
* Also created an importenvs so that we can import envs from the ${HOME}zot/boot dir for dev use
---
* We may want to create a common library/script for functions like printSoftError, printError, etc? 