### PR TITLE
Build/Publish OCI images + misc fixes

### DIFF
--- a/bin/lib/common.inc
+++ b/bin/lib/common.inc
@@ -1,7 +1,7 @@
 #!/bin/sh
 defineColors() 
 {
-  if [ ! "${_BPX_TERMPATH-x}" = "OMVS" ] && [ -z "${NO_COLOR}" ] && [ ! "${FORCE_COLOR-x}" = "0" ]; then
+  if [ ! "${_BPX_TERMPATH-x}" = "OMVS" ] && [ -z "${NO_COLOR}" ] && [ ! "${FORCE_COLOR-x}" = "0" ] && [ -t 1 ] && [ -t 2 ]; then
     esc="\047"
     RED="${esc}[31m"
     GREEN="${esc}[32m"

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -794,11 +794,12 @@ LABEL specification=1.0.0"
 
   cd ${ZOPEN_INSTALL_DIR}
   rm -f zosadkfile
-  mkdir -p .zpm
-  cp .env .zpm/.env
   for file in *; do
     dockerfilecontents="${dockerfilecontents}\nCOPY $file @{CONTAINER_READWRITE}/$file"
   done
+  mkdir -p .zpm
+  cp .env .zpm/.env
+  dockerfilecontents="${dockerfilecontents}\nCOPY .zpm @{CONTAINER_READWRITE}/.zpm"
 
   # zosadk does not support gid greater than 2097151
   gid=$(id | cut -f2 -d' ' | cut -f2 -d'=' | cut -f1 -d'(')

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -696,6 +696,7 @@ install()
     if ! runAndLog "${ZOPEN_PAX_CMD}"; then
       printError "Could not generate pax \"${paxFileName}\""
     fi
+    generateOCI $ZOPEN_NAME
   else
     printHeader "Skipping Install"
   fi
@@ -746,7 +747,7 @@ resolveCommands()
     ZOPEN_NAME="${dir}"
     if [ "${ZOPEN_TYPE}x" = "GITx" ]; then
       branch=$(git rev-parse --abbrev-ref HEAD 2>&1 | sed "s/\//./g")
-      ZOPEN_NAME="${dir}.${branch}"
+      ZOPEN_NAME="${dir}-${branch}"
     fi
     paxFileName="${ZOPEN_NAME}.${LOG_PFX}.zos.pax.Z"
     export ZOPEN_PAX_CMD="pax -w -z -x pax \"-s#${ZOPEN_INSTALL_DIR}/#${ZOPEN_NAME}.${LOG_PFX}.zos/#\" -f \"${paxFileName}\" \"${ZOPEN_INSTALL_DIR}/\""
@@ -756,6 +757,51 @@ resolveCommands()
     unset ZOPEN_PAX_CMD
   fi
   return 0
+}
+
+generateOCI()
+{
+  package=$1
+  name=$(echo $package | cut -d "-" -f 1)
+  version=$(echo $package | cut -d "-" -f 2)
+
+  dockerfilecontents="
+FROM scratch
+
+LABEL name=${name}
+LABEL vendor=OSS
+LABEL version=${version}
+LABEL specification=1.0.0"
+
+  cd ${ZOPEN_INSTALL_DIR}
+  rm -f zosadkfile
+  for file in *; do
+    dockerfilecontents="${dockerfilecontents}\nCOPY $file @{CONTAINER_READWRITE}$file"
+  done
+
+  
+  # zosadk does not support gid greater than 2097151
+  gid=$(id | cut -f2 -d' ' | cut -f2 -d'=' | cut -f1 -d'(')
+  gid2=$(id | cut -f3 -d' ' | cut -f2 -d'=' | cut -f2 -d'(' | cut -f1 -d')')
+  if [ $gid -gt 2097151 ] && [ ! -z $gid ] ; then
+    # Choose a known GID that is less than 2097151
+    chgrp -R $gid2 *
+  fi
+  
+  echo "$dockerfilecontents" > "zosadkfile"
+  if ! iconv -f IBM-1047 -tISO8859-1 <zosadkfile >.zosadkfileascii || ! chtag -tcISO8859-1 .zosadkfileascii || ! mv .zosadkfileascii zosadkfile; then
+    printError "Unable to make .gitattributes ascii for tarball"
+  fi
+
+  zpm config set products_dir $ZPM_PRODUCT_DIR
+  zpm config set products_hlq $LOGNAME
+  zpm config set java_home /usr/lpp/java/IBM/J8.0_64
+  zpm config set registry_credential AKCp8mZwMqw3THJjP1x3uoyNKxuZvqBWTvavY96UTJ4tQuDyormQ2sEQZU4sd5R3P2BgEapFh
+  zpm config set registry_user zosopentools@ibm.com
+  zpm config set registry sys-zosopentools-team-oci-registry-docker-local.artifactory.swg-devops.com
+  zosadk build -t "${name}:${version}" .
+  zosadk push "${name}:${version}" -i sys-zosopentools-team-oci-registry-docker-local.artifactory.swg-devops.com -u zosopentools@ibm.com -p AKCp8mZwMqw3THJjP1x3uoyNKxuZvqBWTvavY96UTJ4tQuDyormQ2sEQZU4sd5R3P2BgEapFh
+  cd -
 }
 
 #

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -780,6 +780,7 @@ generateOCI()
   if ! ${publishOCI}; then
     return 0;
   fi
+  printHeader "Generating OCI Image"
   package=$1
   name=$(echo $package | cut -d "-" -f 1)
   version=$(echo $package | cut -d "-" -f 2)
@@ -801,10 +802,10 @@ LABEL version=${version}
 LABEL specification=1.0.0"
 
   cd ${ZOPEN_INSTALL_DIR}
-  echo "${ZOPEN_IMAGE_DOCKERFILE_NAME}"
   if [ -f "${ZOPEN_IMAGE_DOCKERFILE_NAME}" ]; then
     rm -f "${ZOPEN_IMAGE_DOCKERFILE_NAME}"
   fi
+  printVerbose "Generating ${ZOPEN_IMAGE_DOCKERFILE_NAME}"
   for file in *; do
     dockerfilecontents="${dockerfilecontents}\nCOPY $file @{CONTAINER_READWRITE}/$file"
   done
@@ -835,6 +836,7 @@ LABEL specification=1.0.0"
     printWarning "${ZOPEN_IMAGE_DOCKER_NAME} is not present on your system"
     return 4
   fi
+  printVerbose "Generating OCI Image"
   "${ZOPEN_IMAGE_DOCKER_NAME}" build -t "${name}:${version}" .
   "${ZOPEN_IMAGE_DOCKER_NAME}"push "${name}:${version}" -i $ZOPEN_IMAGE_REGISTRY -u $ZOPEN_IMAGE_REGISTRY_ID -p @$ZOPEN_IMAGE_REGISTRY_KEY_FILE
   cd -

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -795,7 +795,7 @@ LABEL specification=1.0.0"
   cd ${ZOPEN_INSTALL_DIR}
   rm -f zosadkfile
   for file in *; do
-    dockerfilecontents="${dockerfilecontents}\nCOPY $file @{CONTAINER_READWRITE}$file"
+    dockerfilecontents="${dockerfilecontents}\nCOPY $file @{CONTAINER_READWRITE}/$file"
   done
 
   # zosadk does not support gid greater than 2097151

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -48,6 +48,9 @@ ZOPEN_MAKE           Build program to run. If skip is specified, no build step i
 ZOPEN_MAKE_OPTS      Options to pass to build program (defaults to '-j\${ZOPEN_NUM_JOBS}')
 ZOPEN_CHECK          Check program to run. If skip is specified, no check step is performed (defaults to '${ZOPEN_CHECKD}') 
 ZOPEN_CHECK_OPTS     Options to pass to check program (defaults to '${ZOPEN_CHECK_OPTSD}')
+ZOPEN_IMAGE_REGISTRY Docker image registry to an OCI image to (use with --oci option)
+ZOPEN_IMAGE_REGISTRY_ID The ID to authenticate to the Docker image registry (use with --oci option)
+ZOPEN_IMAGE_REGISTRY_KEY_FILE The file containing the key to authenticate to the Docker image registry (use with --oci option)
 ZOPEN_INSTALL        Installation program to run. If skip is specified, no installation step is performed (defaults to '${ZOPEN_INSTALLD}')
 ZOPEN_INSTALL_OPTS   Options to pass to installation program (defaults to '${ZOPEN_INSTALL_OPTSD}')"
 
@@ -92,6 +95,7 @@ printSyntax()
   echo "  where <option> may be one or more of:" >&2
   echo "  -h: print this information" >&2
   echo "  -v: run in verbose mode" >&2
+  echo "  --oci: publish OCI to \$ZOPEN_IMAGE_REGISTRY" >&2
   echo "  -e <env file>: source <env file> instead of buildenv to establish build environment" >&2
   echo "  -s: exec a shell before running configure.  Useful when manually building ports." >&2
   opts=$(printEnvVar)
@@ -102,6 +106,7 @@ processOptions()
 {
   args=$*
   verbose=false
+  publishOCI=false
   skipcheck=false
   startShell=false
   buildEnvFile="./buildenv"
@@ -114,6 +119,9 @@ processOptions()
         ;;
       "-v" | "--v" | "-verbose" | "--verbose")
         verbose=true
+        ;;
+      "-oci" | "--oci")
+        publishOCI=true
         ;;
       "-sc" | "--skipcheck")
         skipcheck=true
@@ -761,6 +769,9 @@ resolveCommands()
 
 generateOCI()
 {
+  if ! ${publishOCI}; then
+    return 0;
+  fi
   package=$1
   name=$(echo $package | cut -d "-" -f 1)
   version=$(echo $package | cut -d "-" -f 2)
@@ -783,7 +794,7 @@ LABEL specification=1.0.0"
   # zosadk does not support gid greater than 2097151
   gid=$(id | cut -f2 -d' ' | cut -f2 -d'=' | cut -f1 -d'(')
   gid2=$(id | cut -f3 -d' ' | cut -f2 -d'=' | cut -f2 -d'(' | cut -f1 -d')')
-  if [ $gid -gt 2097151 ] && [ ! -z $gid ] ; then
+  if [ $gid -gt 2097151 ] && [ ! -z $gid2 ] ; then
     # Choose a known GID that is less than 2097151
     chgrp -R $gid2 *
   fi
@@ -793,14 +804,24 @@ LABEL specification=1.0.0"
     printError "Unable to make .gitattributes ascii for tarball"
   fi
 
-  zpm config set products_dir $ZPM_PRODUCT_DIR
-  zpm config set products_hlq $LOGNAME
-  zpm config set java_home /usr/lpp/java/IBM/J8.0_64
-  zpm config set registry_credential AKCp8mZwMqw3THJjP1x3uoyNKxuZvqBWTvavY96UTJ4tQuDyormQ2sEQZU4sd5R3P2BgEapFh
-  zpm config set registry_user zosopentools@ibm.com
-  zpm config set registry sys-zosopentools-team-oci-registry-docker-local.artifactory.swg-devops.com
+  if [ -z $ZOPEN_IMAGE_REGISTRY ]; then
+    printWarning "Environment variable ZOPEN_IMAGE_REGISTRY is needed to push an OCI image"
+    return 4;
+  fi
+  if [ -z $ZOPEN_IMAGE_REGISTRY_ID ]; then
+    printWarning "Environment variable ZOPEN_IMAGE_REGISTRY_ID is needed to push an OCI image"
+    return 4;
+  fi
+  if [ -z $ZOPEN_IMAGE_REGISTRY_KEY_FILE ] || [ ! -r $ZOPEN_IMAGE_REGISTRY_KEY_FILE ]; then
+    printWarning "Environment variable ZOPEN_IMAGE_REGISTRY_KEY_FILE is needed to push an OCI image"
+    return 4;
+  fi
+  if [ -z "$(command -v zosadk)" ]; then
+    printWarning "zosadk is not present on your system"
+    return 4
+  fi
   zosadk build -t "${name}:${version}" .
-  zosadk push "${name}:${version}" -i sys-zosopentools-team-oci-registry-docker-local.artifactory.swg-devops.com -u zosopentools@ibm.com -p AKCp8mZwMqw3THJjP1x3uoyNKxuZvqBWTvavY96UTJ4tQuDyormQ2sEQZU4sd5R3P2BgEapFh
+  zosadk push "${name}:${version}" -i $ZOPEN_IMAGE_REGISTRY -u $ZOPEN_IMAGE_REGISTRY_ID -p @$ZOPEN_IMAGE_REGISTRY_KEY_FILE
   cd -
 }
 

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -95,7 +95,7 @@ printSyntax()
   echo "  where <option> may be one or more of:" >&2
   echo "  -h: print this information" >&2
   echo "  -v: run in verbose mode" >&2
-  echo "  --oci: publish OCI to \$ZOPEN_IMAGE_REGISTRY" >&2
+  echo "  --oci: build and publish an OCI image to \$ZOPEN_IMAGE_REGISTRY" >&2
   echo "  -e <env file>: source <env file> instead of buildenv to establish build environment" >&2
   echo "  -s: exec a shell before running configure.  Useful when manually building ports." >&2
   opts=$(printEnvVar)

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -776,6 +776,14 @@ generateOCI()
   name=$(echo $package | cut -d "-" -f 1)
   version=$(echo $package | cut -d "-" -f 2)
 
+  # Make the version OCI compat
+  case "$version" in
+      *.*.*.*) ;;
+      *.*.*)  version="$version.0";;
+      *.*)  version="$version.0.0";;
+      *) version="1.0.0.0";;
+  esac
+
   dockerfilecontents="
 FROM scratch
 
@@ -790,7 +798,6 @@ LABEL specification=1.0.0"
     dockerfilecontents="${dockerfilecontents}\nCOPY $file @{CONTAINER_READWRITE}$file"
   done
 
-  
   # zosadk does not support gid greater than 2097151
   gid=$(id | cut -f2 -d' ' | cut -f2 -d'=' | cut -f1 -d'(')
   gid2=$(id | cut -f3 -d' ' | cut -f2 -d'=' | cut -f2 -d'(' | cut -f1 -d')')

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -794,6 +794,8 @@ LABEL specification=1.0.0"
 
   cd ${ZOPEN_INSTALL_DIR}
   rm -f zosadkfile
+  mkdir -p .zpm
+  cp .env .zpm/.env
   for file in *; do
     dockerfilecontents="${dockerfilecontents}\nCOPY $file @{CONTAINER_READWRITE}/$file"
   done

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -49,6 +49,8 @@ ZOPEN_MAKE_OPTS      Options to pass to build program (defaults to '-j\${ZOPEN_N
 ZOPEN_CHECK          Check program to run. If skip is specified, no check step is performed (defaults to '${ZOPEN_CHECKD}') 
 ZOPEN_CHECK_OPTS     Options to pass to check program (defaults to '${ZOPEN_CHECK_OPTSD}')
 ZOPEN_IMAGE_REGISTRY Docker image registry to an OCI image to (use with --oci option)
+ZOPEN_IMAGE_DOCKERFILE_NAME Dockerfile name (default: Dockerfile)
+ZOPEN_IMAGE_DOCKER_NAME Docker/podman tool name (default: podman)
 ZOPEN_IMAGE_REGISTRY_ID The ID to authenticate to the Docker image registry (use with --oci option)
 ZOPEN_IMAGE_REGISTRY_KEY_FILE The file containing the key to authenticate to the Docker image registry (use with --oci option)
 ZOPEN_INSTALL        Installation program to run. If skip is specified, no installation step is performed (defaults to '${ZOPEN_INSTALLD}')
@@ -76,6 +78,12 @@ setDefaults()
   export ZOPEN_CHECK_OPTSD="check"
   export ZOPEN_INSTALLD="make"
   export ZOPEN_INSTALL_OPTSD="install"
+  if [ -z "$ZOPEN_IMAGE_DOCKERFILE_NAME" ]; then
+    export ZOPEN_IMAGE_DOCKERFILE_NAME="Dockerfile"
+  fi
+  if [ -z "$ZOPEN_IMAGE_DOCKER_NAME" ]; then
+    export ZOPEN_IMAGE_DOCKER_NAME="podman"
+  fi
 }
 
 printSyntax()
@@ -793,25 +801,22 @@ LABEL version=${version}
 LABEL specification=1.0.0"
 
   cd ${ZOPEN_INSTALL_DIR}
-  rm -f zosadkfile
+  echo "${ZOPEN_IMAGE_DOCKERFILE_NAME}"
+  if [ -f "${ZOPEN_IMAGE_DOCKERFILE_NAME}" ]; then
+    rm -f "${ZOPEN_IMAGE_DOCKERFILE_NAME}"
+  fi
   for file in *; do
     dockerfilecontents="${dockerfilecontents}\nCOPY $file @{CONTAINER_READWRITE}/$file"
   done
+
+  # Add required .env file
   mkdir -p .zpm
   cp .env .zpm/.env
   dockerfilecontents="${dockerfilecontents}\nCOPY .zpm @{CONTAINER_READWRITE}/.zpm"
 
-  # zosadk does not support gid greater than 2097151
-  gid=$(id | cut -f2 -d' ' | cut -f2 -d'=' | cut -f1 -d'(')
-  gid2=$(id | cut -f3 -d' ' | cut -f2 -d'=' | cut -f2 -d'(' | cut -f1 -d')')
-  if [ $gid -gt 2097151 ] && [ ! -z $gid2 ] ; then
-    # Choose a known GID that is less than 2097151
-    chgrp -R $gid2 *
-  fi
-  
-  echo "$dockerfilecontents" > "zosadkfile"
-  if ! iconv -f IBM-1047 -tISO8859-1 <zosadkfile >.zosadkfileascii || ! chtag -tcISO8859-1 .zosadkfileascii || ! mv .zosadkfileascii zosadkfile; then
-    printError "Unable to make .gitattributes ascii for tarball"
+  echo "$dockerfilecontents" > "${ZOPEN_IMAGE_DOCKERFILE_NAME}"
+  if ! iconv -f IBM-1047 -tISO8859-1 <"${ZOPEN_IMAGE_DOCKERFILE_NAME}">".${ZOPEN_IMAGE_DOCKERFILE_NAME}ascii" || ! chtag -tcISO8859-1 ".${ZOPEN_IMAGE_DOCKERFILE_NAME}ascii" || ! mv ".${ZOPEN_IMAGE_DOCKERFILE_NAME}ascii" ${ZOPEN_IMAGE_DOCKERFILE_NAME}; then
+    printError "Unable to make ${ZOPEN_IMAGE_DOCKERFILE_NAME}"
   fi
 
   if [ -z $ZOPEN_IMAGE_REGISTRY ]; then
@@ -826,12 +831,12 @@ LABEL specification=1.0.0"
     printWarning "Environment variable ZOPEN_IMAGE_REGISTRY_KEY_FILE is needed to push an OCI image"
     return 4;
   fi
-  if [ -z "$(command -v zosadk)" ]; then
-    printWarning "zosadk is not present on your system"
+  if [ -z "$(command -v ${ZOPEN_IMAGE_DOCKER_NAME})" ]; then
+    printWarning "${ZOPEN_IMAGE_DOCKER_NAME} is not present on your system"
     return 4
   fi
-  zosadk build -t "${name}:${version}" .
-  zosadk push "${name}:${version}" -i $ZOPEN_IMAGE_REGISTRY -u $ZOPEN_IMAGE_REGISTRY_ID -p @$ZOPEN_IMAGE_REGISTRY_KEY_FILE
+  "${ZOPEN_IMAGE_DOCKER_NAME}" build -t "${name}:${version}" .
+  "${ZOPEN_IMAGE_DOCKER_NAME}"push "${name}:${version}" -i $ZOPEN_IMAGE_REGISTRY -u $ZOPEN_IMAGE_REGISTRY_ID -p @$ZOPEN_IMAGE_REGISTRY_KEY_FILE
   cd -
 }
 

--- a/bin/lib/zopen-download
+++ b/bin/lib/zopen-download
@@ -47,15 +47,20 @@ if [ ! -z "${download}" -a -d "${download}" ]; then
 fi
 
 #FIXME: Once jq is ported, rewrite with jq
-if ! repo_results=$(curl -s "https://api.github.com/users/ZOSOpenTools/repos?per_page=100" 2>/dev/null | grep "\"full_name\":" | cut -d '"' -f 4); then
+if ! repo_results=$(curl -k -s "https://api.github.com/users/ZOSOpenTools/repos?per_page=100" 2>/dev/null | grep "\"full_name\":" | cut -d '"' -f 4); then
   printError "curl command could not download the z/OS Open Tools repository list"
 fi
 
 for repo in $(echo ${repo_results}); do
   repo=${repo#"ZOSOpenTools/"}
   if [ -z $toolrepo ] || [ "${toolrepo}" = "${repo}" ]; then
+    name=${repo%port}
+    if [ "${repo}" == "${name}" ]; then
+      continue;
+    fi
+    if test "${string#*$substring}" != "$string"
     printHeader "Downloading latest release from $repo"
-    if ! latest_url=$(curl -s https://api.github.com/repos/ZOSOpenTools/${repo}/releases/latest 2>/dev/null | grep browser_download_url | cut -d '"' -f 4); then
+    if ! latest_url=$(curl -k -s https://api.github.com/repos/ZOSOpenTools/${repo}/releases/latest 2>/dev/null | grep browser_download_url | cut -d '"' -f 4); then
       printError "Could not find the latest url for $repo"
     fi
 
@@ -64,7 +69,7 @@ for repo in $(echo ${repo_results}); do
       continue
     fi
 
-    if ! curl -L ${latest_url} -O 2>/dev/null; then
+    if ! curl -k -L ${latest_url} -O 2>/dev/null; then
       printError "Could not download ${latest_url}"
     fi
 
@@ -80,7 +85,6 @@ for repo in $(echo ${repo_results}); do
     fi
     rm -f "${pax}"
     dirname=${pax%.pax.Z}
-    name=${repo%port}
     if [ -L $name ]; then
       rm $name
     fi 

--- a/bin/lib/zopen-download
+++ b/bin/lib/zopen-download
@@ -58,7 +58,6 @@ for repo in $(echo ${repo_results}); do
     if [ "${repo}" == "${name}" ]; then
       continue;
     fi
-    if test "${string#*$substring}" != "$string"
     printHeader "Downloading latest release from $repo"
     if ! latest_url=$(curl -k -s https://api.github.com/repos/ZOSOpenTools/${repo}/releases/latest 2>/dev/null | grep browser_download_url | cut -d '"' -f 4); then
       printError "Could not find the latest url for $repo"

--- a/bin/lib/zopen-download
+++ b/bin/lib/zopen-download
@@ -55,7 +55,7 @@ for repo in $(echo ${repo_results}); do
   repo=${repo#"ZOSOpenTools/"}
   if [ -z $toolrepo ] || [ "${toolrepo}" = "${repo}" ]; then
     name=${repo%port}
-    if [ "${repo}" == "${name}" ]; then
+    if [ "${repo}" = "${name}" ]; then
       continue;
     fi
     printHeader "Downloading latest release from $repo"


### PR DESCRIPTION
* Removes color escaping when redirecting to a file
* Adds initial support for creating OCI artifacts via the --oci option
* Also fixes zopen download where repos not ending with port would be considered