### PR TITLE
Adds default .env (with ability to append entries) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ To build a software package, you can use `zopen build`.
 -  `buildenv`, which `zopen build` will automatically source.  If you would like to source another file, you can specify it via the `-e` option as in: `zopen build -e mybuildenv`
 
 The `buildenv` file _must_ set the following environment variables:
-- `ZOPEN_ROOT`: this environment variable is the absolute directory of the location the repo was clone'd to
 - `ZOPEN_TYPE`: one of _TARBALL_ or _GIT_ indicating where the source should be pulled from (a source tarball or git repository)
 - `ZOPEN_URL`: the URL where the source should be pulled from, including the `package.git` or `package-V.R.M.tar.gz` extension
 - `ZOPEN_DEPS`: a space-separated list of all software dependencies this package has.
@@ -59,4 +58,3 @@ Run `zopen build` from the root directory of the git repo you would like to buil
 cd ${HOME}/zot/dev/m4
 ${HOME}/zot/dev/utils/bin/zopen build
 ```
-

--- a/README.md
+++ b/README.md
@@ -25,14 +25,23 @@ To build a software package, you can use `zopen build`.
 
 `zopen build` requires the files scripts in the project's root directory:
 -  `buildenv`, which `zopen build` will automatically source.  If you would like to source another file, you can specify it via the `-e` option as in: `zopen build -e mybuildenv`
-- `portchk.sh`, so that the test process can check that the build is _good enough_ to be considered for installation.
-- `portcrtenv.sh`, so that the install process can create the corresponding `.env` file for the software product.  For _boot_ products from Rocket, the developer will need to create the corresponding `.env` file (or copy one already made by another developer). 
 
 The `buildenv` file _must_ set the following environment variables:
 - `ZOPEN_ROOT`: this environment variable is the absolute directory of the location the repo was clone'd to
 - `ZOPEN_TYPE`: one of _TARBALL_ or _GIT_ indicating where the source should be pulled from (a source tarball or git repository)
 - `ZOPEN_URL`: the URL where the source should be pulled from, including the `package.git` or `package-V.R.M.tar.gz` extension
 - `ZOPEN_DEPS`: a space-separated list of all software dependencies this package has.
+
+To help guage the health of the port, a zopen_check_results function can be provided inside the buildenv. The following return codes map to a given status:
+- 0 - Green - All tests passed
+- 1 - Blue - Most tests passed
+- 2 - Yellow - Most tests failed
+- 3 - Red - All tests failed or check is broken
+- 4 - Unknown - Skipped or something went wrong
+
+`zopen build` will generate a .env file in the install location with support for environment variables such as PATH, LIBPATH, and MANPATH.
+To add your own, you can append environment variables by echo'ing them in a function called zopen_append_to_env.
+
 Note that you can choose the fully-qualified environment variables ZOPEN_GIT_URL, ZOPEN_GIT_DEPS and ZOPEN_TARBALL_URL, ZOPEN_TARBALL_DEPS 
 accordingly if you prefer. See (https://github.com/ZOSOpenTools/zotsampleport/blob/main/setenv.sh) for an example.
 
@@ -40,6 +49,8 @@ There are several additional environment variables that can be specified to prov
 For details
 - Run `zopen build -h` for a description of all the environment variables
 - Read the code: (https://github.com/ZOSOpenTools/utils/blob/main/bin/zopen-build). 
+
+For a sample port, visit the [zotsampleport](https://github.com/ZOSOpenTools/zotsampleport) repo.
 
 ### Running zopen build
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ To help guage the health of the port, a zopen_check_results function can be prov
 - 3 - Red - All tests failed or check is broken
 - 4 - Unknown - Skipped or something went wrong
 
+To get started, generate a zopen project with `zopen generate`
+
 `zopen build` will generate a .env file in the install location with support for environment variables such as PATH, LIBPATH, and MANPATH.
 To add your own, you can append environment variables by echo'ing them in a function called zopen_append_to_env.
 

--- a/bin/lib/common.inc
+++ b/bin/lib/common.inc
@@ -80,4 +80,10 @@ printInfo()
   printf "$1\n" >&2
 }
 
+getInput()
+{
+  read zopen_input
+  echo $zopen_input
+}
+
 zopenInitialize

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -46,8 +46,6 @@ ZOPEN_MAKE           Build program to run. If skip is specified, no build step i
 ZOPEN_MAKE_OPTS      Options to pass to build program (defaults to '-j\${ZOPEN_NUM_JOBS}')
 ZOPEN_CHECK          Check program to run. If skip is specified, no check step is performed (defaults to '${ZOPEN_CHECKD}') 
 ZOPEN_CHECK_OPTS     Options to pass to check program (defaults to '${ZOPEN_CHECK_OPTSD}')
-ZOPEN_MAKE_OPTS      Options to pass to build program (defaults to '-j\${ZOPEN_NUM_JOBS}')
-ZOPEN_CHECK          Check program to run. If skip is specified, no check step is performed (defaults to '${ZOPEN_CHECKD}') 
 ZOPEN_CHECK_OPTS     Options to pass to check program (defaults to '${ZOPEN_CHECK_OPTSD}')
 ZOPEN_IMAGE_REGISTRY Docker image registry to an OCI image to (use with --oci option)
 ZOPEN_IMAGE_DOCKERFILE_NAME Dockerfile name (default: Dockerfile)
@@ -63,6 +61,24 @@ export utildir="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P)"
 export utilparentdir="$(cd "$(dirname "$0")/../.." >/dev/null 2>&1 && pwd -P)"
 
 . "${utildir}/common.inc"
+
+# Temporary files
+for tmp in "$TMPDIR" "$TMP" /tmp
+do
+  if [ ! -z $tmp ] && [ -d $tmp ]; then
+    temp_c_file="$tmp/$LOGNAME.c"
+    break
+  fi
+done
+
+# Remove temoraries on exit
+cleanup() {
+    rv=$?
+    [ -f $temp_c_file ] && /bin/rm -rf $temp_c_file
+    exit $rv
+}
+
+trap "cleanup" EXIT INT TERM QUIT HUP
 
 setDefaults()
 {
@@ -213,7 +229,7 @@ checkEnv()
     printError "ZOPEN_TYPE must be one of TARBALL or GIT. ZOPEN_TYPE=${ZOPEN_TYPE} was specified"
   fi
 
-  export ZOPEN_CHECK_RESULTS="zopen_check_results"
+  ZOPEN_CHECK_RESULTS="zopen_check_results"
   if command -V "${ZOPEN_CHECK_RESULTS}" >/dev/null 2>&1; then
     export ZOPEN_CHECK_RESULTS="${ZOPEN_ROOT}/portchk.sh"
     if ! [ -x "${ZOPEN_CHECK_RESULTS}" ]; then
@@ -221,7 +237,7 @@ checkEnv()
     fi
   fi
 
-  export ZOPEN_APPEND_TO_ENV="zopen_append_to_env"
+  ZOPEN_APPEND_TO_ENV="zopen_append_to_env"
 
   if [ "${ZOPEN_TYPE}x" = "TARBALLx" ]; then
     if [ "${ZOPEN_TARBALL_URL}x" = "x" ]; then
@@ -300,7 +316,6 @@ setEnv()
     export CXXFLAGS="${ZOPEN_CXXFLAGSD} ${ZOPEN_EXTRA_CXXFLAGS}"
   fi
 
-  temp_c_file="/tmp/$LOGNAME.c"
   if [ "${CC}x" = "xlclangx" ]; then
     # Confirm xlclang is at least 1.0.0 (aka __COMPILER_VER__=42040001)
     ccraw=$(touch $temp_c_file && xlclang -E -qshowmacros $temp_c_file | grep '__COMPILER_VER__' | awk '{print substr($3,3)}')
@@ -691,17 +706,17 @@ check()
     printHeader "Skipping Check"
   fi
   case "$results" in
-    0) status="Green" ;; # All tests passed
-    1) status="Blue" ;; # Most tests passed
-    2) status="Yellow" ;; # Most tests failed
-    3) status="Red" ;; # Pretty much non-functional
-    *) status="Unknown" ;; # Skipped or bad return code from check results
+    0) ZOPEN_STATUS="Green" ;; # All tests passed
+    1) ZOPEN_STATUS="Blue" ;; # Most tests passed
+    2) ZOPEN_STATUS="Yellow" ;; # Most tests failed
+    3) ZOPEN_STATUS="Red" ;; # Pretty much non-functional
+    *) ZOPEN_STATUS="Unknown" ;; # Skipped or bad return code from check results
   esac
-  echo "$status" >> "${ZOPEN_INSTALL_DIR}/build.status"
 }
 
 createEnv()
 {
+  projectName=$(echo $ZOPEN_NAME | cut -d "-" -f 1 | awk '{print toupper($0)}')
   cat <<zz >"${ZOPEN_INSTALL_DIR}/.env"
 if ! [ -f ./.env ]; then
   echo "Need to source from the .env directory" >&2
@@ -712,6 +727,7 @@ export _CEE_RUNOPTS="\$_CEE_RUNOPTS FILETAG(AUTOCVT,AUTOTAG) POSIX(ON)"
 export _TAG_REDIR_IN=txt
 export _TAG_REDIR_ERR=txt
 export _TAG_REDIR_OUT=txt
+export ${projectName}_HOME=\${PWD}
 zz
 
   if [ -d "${ZOPEN_INSTALL_DIR}/bin" ]; then
@@ -738,6 +754,7 @@ install()
       printError "Install failed. Log: ${installlog}"
     fi
     createEnv
+    echo "$ZOPEN_STATUS" >> "${ZOPEN_INSTALL_DIR}/build.status"
     if command -V "zopen_post_install" >/dev/null 2>&1; then
       zopen_post_install ${ZOPEN_INSTALL_DIR}
     fi

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -780,8 +780,7 @@ resolveCommands()
   fi
 
   if [ "${ZOPEN_CHECK}x" != "skipx" ] && [ ! -z "$(command -v ${ZOPEN_CHECK})" ] && ! ${skipcheck}; then
-    export ZOPEN_CHECK_CMD="\"${ZOPEN_CHECK}\" ${ZOPEN_CHECK_OPTS} CC=${CC} \"CPPFLAGS=${CPPFLAGS}\" \"CFLAGS=${CFLAGS}\" CXX=${CXX} \"CXXFLAGS=${CXXFLAGS}\" \"L
-DFLAGS=${LDFLAGS}\""
+    export ZOPEN_CHECK_CMD="\"${ZOPEN_CHECK}\" ${ZOPEN_CHECK_OPTS} CC=${CC} \"CPPFLAGS=${CPPFLAGS}\" \"CFLAGS=${CFLAGS}\" CXX=${CXX} \"CXXFLAGS=${CXXFLAGS}\" \"LDFLAGS=${LDFLAGS}\""
     export ZOPEN_CHECK_RESULTS_CMD="\"${ZOPEN_CHECK_RESULTS}\" \"${ZOPEN_ROOT}/${dir}\" \"${LOG_PFX}\""
   else
     unset ZOPEN_CHECK_CMD
@@ -949,3 +948,5 @@ fi
 if ! install; then
   exit 4
 fi
+
+exit 0

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -12,6 +12,11 @@
 # Functions section
 #
 
+# Temporary files:
+temp_c_file="/tmp/$LOGNAME.$RANDOM.c"
+
+trap "/bin/rm -rf $temp_c_file && exit" EXIT INT TERM QUIT HUP
+
 printEnvVar()
 {
   echo "\
@@ -304,31 +309,26 @@ setEnv()
     export CXXFLAGS="${ZOPEN_CXXFLAGSD} ${ZOPEN_EXTRA_CXXFLAGS}"
   fi
 
+  temp_c_file="/tmp/$LOGNAME.c"
   if [ "${CC}x" = "xlclangx" ]; then
-    # Confirm xlclang is at least 1.0.0
-    ccraw=$(xlclang -qversion | grep 'IBM C/C++ for Open Enterprise Languages on z/OS' | awk '{print substr($9,2)}')
+    # Confirm xlclang is at least 1.0.0 (aka __COMPILER_VER__=42040001)
+    ccraw=$(touch $temp_c_file && xlclang -E -qshowmacros $temp_c_file | grep '__COMPILER_VER__' | awk '{print substr($3,3)}')
     if [ "${ccraw}x" = "x" ]; then
-      printWarning "xlclang compiler specified, but it is not a 'IBM C/C++ for Open Enterprise Languages on z/OS' compiler"
+      printError "xlclang compiler specified, but it is not a 'IBM C/C++ for Open Enterprise Languages on z/OS' compiler"
     fi 
-    v=${ccraw%%.*}
-    vr=${ccraw%.*}
-    r=${vr##*.}
-    if [ ${v} -lt 1 ] ; then
-      printWarning "Need to be running at least IBM C for Open Enterprise Languages on z/OS 1"
+    if [ ${ccraw} -lt 42040001 ] ; then
+      printError "Need to be running at least IBM C for Open Enterprise Languages on z/OS 1"
     fi
   fi
 
   if [ "${CXX}x" = "xlclang++x" ]; then
-    # Confirm xlclang++ is at least 1.0.0
-    ccraw=$(xlclang++ -qversion | grep 'IBM C/C++ for Open Enterprise Languages on z/OS' | awk '{print substr($9,2)}')
+    # Confirm xlclang is at least 1.0.0 (aka __COMPILER_VER__=42040001)
+    ccraw=$(touch $temp_c_file && xlclang++ -+ -E -qshowmacros $temp_c_file | grep '__COMPILER_VER__' | awk '{print substr($3,3)}')
     if [ "${ccraw}x" = "x" ]; then
-      printWarning "xlclang++ compiler specified, but it is not a 'IBM C/C++ for Open Enterprise Languages on z/OS' compiler"
+      printError "xlclang compiler specified, but it is not a 'IBM C/C++ for Open Enterprise Languages on z/OS' compiler"
     fi 
-    v=${ccraw%%.*}
-    vr=${ccraw%.*}
-    r=${vr##*.}
-    if [ ${v} -lt 1 ] ; then
-      printWarning "Need to be running at least IBM C++ for Open Enterprise Languages on z/OS 1"
+    if [ ${ccraw} -lt 42040001 ] ; then
+      printError "Need to be running at least IBM C for Open Enterprise Languages on z/OS 1"
     fi
   fi
 
@@ -688,7 +688,7 @@ build()
 check()
 {
   checklog="${LOG_PFX}_check.log"
-  results=2 # Assume the worst
+  results=4 # Unknown results
   if [ -n "${ZOPEN_CHECK_CMD}" ]; then
     printHeader "Running Check"
     runAndLog "${ZOPEN_CHECK_CMD} >\"${checklog}\""
@@ -700,10 +700,11 @@ check()
     printHeader "Skipping Check"
   fi
   case "$results" in
-    0) status="Green" ;;
-    1) status="Yellow" ;;
-    2) status="Red" ;;
-    *) status="Red" ;;
+    0) status="Green" ;; # All tests passed
+    1) status="Blue" ;; # Most tests passed
+    2) status="Yellow" ;; # Most tests failed
+    3) status="Red" ;; # Pretty much non-functional
+    *) status="Unknown" ;; # Skipped or bad return code from check results
   esac
   echo "$status" >> "${ZOPEN_INSTALL_DIR}/build.status"
 }
@@ -727,6 +728,9 @@ zz
   fi
   if [ -d "${ZOPEN_INSTALL_DIR}/lib" ]; then
     echo "export LIBPATH=\"\${PWD}/lib:\$LIBPATH\"" >> "${ZOPEN_INSTALL_DIR}/.env"
+  fi
+  if [ -d "${ZOPEN_INSTALL_DIR}/share/man" ]; then
+    echo "export MANPATH=\"\${PWD}/share/man:\$MANPATH" >> "${ZOPEN_INSTALL_DIR}/.env"
   fi
   if command -V "${ZOPEN_APPEND_TO_ENV}" >/dev/null 2>&1; then
     append_to_env="$(${ZOPEN_APPEND_TO_ENV})"

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -727,7 +727,6 @@ zz
     append_to_env="$(${ZOPEN_APPEND_TO_ENV})"
     echo "$append_to_env" >> "${ZOPEN_INSTALL_DIR}/.env"
   fi
-  exit 0
 }
 
 install()
@@ -739,6 +738,9 @@ install()
       printError "Install failed. Log: ${installlog}"
     fi
     createEnv
+    if command -V "zopen_post_install" >/dev/null 2>&1; then
+      zopen_post_install ${ZOPEN_INSTALL_DIR}
+    fi
     if ! runAndLog "${ZOPEN_PAX_CMD}"; then
       printError "Could not generate pax \"${paxFileName}\""
     fi

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -217,14 +217,15 @@ checkEnv()
     printError "ZOPEN_TYPE must be one of TARBALL or GIT. ZOPEN_TYPE=${ZOPEN_TYPE} was specified"
   fi
 
-  export ZOPEN_CHECK_RESULTS="${ZOPEN_ROOT}/portchk.sh"
-  export ZOPEN_CREATE_ENV="${ZOPEN_ROOT}/portcrtenv.sh"
-  if ! [ -x "${ZOPEN_CHECK_RESULTS}" ]; then
-    printError "${ZOPEN_CHECK_RESULTS} script needs to be provided to check the results. Exit with 0 if the build can be installed"
+  export ZOPEN_CHECK_RESULTS="zopen_check_results"
+  if command -V "${ZOPEN_CHECK_RESULTS}" >/dev/null 2>&1; then
+    export ZOPEN_CHECK_RESULTS="${ZOPEN_ROOT}/portchk.sh"
+    if ! [ -x "${ZOPEN_CHECK_RESULTS}" ]; then
+      printError "${ZOPEN_CHECK_RESULTS} script needs to be provided to check the results. Exit with 0 for Green, 1 for Yellow, and 2 for Red"
+    fi
   fi
-  if ! [ -x "${ZOPEN_CREATE_ENV}" ]; then
-    printError "${ZOPEN_CREATE_ENV} script needs to be provided to define the environment"
-  fi
+
+  export ZOPEN_APPEND_TO_ENV="zopen_append_to_env"
 
   if [ "${ZOPEN_TYPE}x" = "TARBALLx" ]; then
     if [ "${ZOPEN_TARBALL_URL}x" = "x" ]; then
@@ -687,15 +688,51 @@ build()
 check()
 {
   checklog="${LOG_PFX}_check.log"
+  results=2 # Assume the worst
   if [ -n "${ZOPEN_CHECK_CMD}" ]; then
     printHeader "Running Check"
     runAndLog "${ZOPEN_CHECK_CMD} >\"${checklog}\""
-    if ! runAndLog "${ZOPEN_CHECK_RESULTS_CMD}"; then
-      printError "Check failed. Log: ${checklog}"
+    if command -V "${ZOPEN_CHECK_RESULTS}" >/dev/null 2>&1; then
+      ${ZOPEN_CHECK_RESULTS} "${ZOPEN_ROOT}/${dir}" "${LOG_PFX}"
+      results=$?
     fi
   else
     printHeader "Skipping Check"
   fi
+  case "$results" in
+    0) status="Green" ;;
+    1) status="Yellow" ;;
+    2) status="Red" ;;
+    *) status="Red" ;;
+  esac
+  echo "$status" >> "${ZOPEN_INSTALL_DIR}/build.status"
+}
+
+createEnv()
+{
+  cat <<zz >"${ZOPEN_INSTALL_DIR}/.env"
+if ! [ -f ./.env ]; then
+  echo "Need to source from the .env directory" >&2
+  return 0
+fi
+export _BPXK_AUTOCVT=ON
+export _CEE_RUNOPTS="\$_CEE_RUNOPTS FILETAG(AUTOCVT,AUTOTAG) POSIX(ON)"
+export _TAG_REDIR_IN=txt
+export _TAG_REDIR_ERR=txt
+export _TAG_REDIR_OUT=txt
+zz
+
+  if [ -d "${ZOPEN_INSTALL_DIR}/bin" ]; then
+    echo "export PATH=\"\${PWD}/bin:\$PATH\"" >> "${ZOPEN_INSTALL_DIR}/.env"
+  fi
+  if [ -d "${ZOPEN_INSTALL_DIR}/lib" ]; then
+    echo "export LIBPATH=\"\${PWD}/lib:\$LIBPATH\"" >> "${ZOPEN_INSTALL_DIR}/.env"
+  fi
+  if command -V "${ZOPEN_APPEND_TO_ENV}" >/dev/null 2>&1; then
+    append_to_env="$(${ZOPEN_APPEND_TO_ENV})"
+    echo "$append_to_env" >> "${ZOPEN_INSTALL_DIR}/.env"
+  fi
+  exit 0
 }
 
 install()
@@ -706,9 +743,7 @@ install()
     if ! runAndLog "${ZOPEN_INSTALL_CMD} >\"${installlog}\""; then
       printError "Install failed. Log: ${installlog}"
     fi
-    if ! runAndLog "${ZOPEN_CREATE_ENV_CMD}"; then
-      printError "Environment creation failed."
-    fi
+    createEnv
     if ! runAndLog "${ZOPEN_PAX_CMD}"; then
       printError "Could not generate pax \"${paxFileName}\""
     fi
@@ -750,7 +785,8 @@ resolveCommands()
   fi
 
   if [ "${ZOPEN_CHECK}x" != "skipx" ] && [ ! -z "$(command -v ${ZOPEN_CHECK})" ] && ! ${skipcheck}; then
-    export ZOPEN_CHECK_CMD="\"${ZOPEN_CHECK}\" ${ZOPEN_CHECK_OPTS} CC=${CC} \"CPPFLAGS=${CPPFLAGS}\" \"CFLAGS=${CFLAGS}\" CXX=${CXX} \"CXXFLAGS=${CXXFLAGS}\" \"LDFLAGS=${LDFLAGS}\""
+    export ZOPEN_CHECK_CMD="\"${ZOPEN_CHECK}\" ${ZOPEN_CHECK_OPTS} CC=${CC} \"CPPFLAGS=${CPPFLAGS}\" \"CFLAGS=${CFLAGS}\" CXX=${CXX} \"CXXFLAGS=${CXXFLAGS}\" \"L
+DFLAGS=${LDFLAGS}\""
     export ZOPEN_CHECK_RESULTS_CMD="\"${ZOPEN_CHECK_RESULTS}\" \"${ZOPEN_ROOT}/${dir}\" \"${LOG_PFX}\""
   else
     unset ZOPEN_CHECK_CMD
@@ -759,7 +795,6 @@ resolveCommands()
 
   if [ "${ZOPEN_INSTALL}x" != "skipx" ] && [ ! -z "$(command -v ${ZOPEN_INSTALL})" ]; then
     export ZOPEN_INSTALL_CMD="${ZOPEN_INSTALL} ${ZOPEN_INSTALL_OPTS}"
-    export ZOPEN_CREATE_ENV_CMD="${ZOPEN_CREATE_ENV} \"${ZOPEN_INSTALL_DIR}\" \"${LOG_PFX}\""
     ZOPEN_NAME="${dir}"
     if [ "${ZOPEN_TYPE}x" = "GITx" ]; then
       branch=$(git rev-parse --abbrev-ref HEAD 2>&1 | sed "s/\//./g")
@@ -769,7 +804,6 @@ resolveCommands()
     export ZOPEN_PAX_CMD="pax -w -z -x pax \"-s#${ZOPEN_INSTALL_DIR}/#${ZOPEN_NAME}.${LOG_PFX}.zos/#\" -f \"${paxFileName}\" \"${ZOPEN_INSTALL_DIR}/\""
   else
     unset ZOPEN_INSTALL_CMD
-    unset ZOPEN_CREATE_ENV_CMD
     unset ZOPEN_PAX_CMD
   fi
   return 0

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -46,7 +46,6 @@ ZOPEN_MAKE           Build program to run. If skip is specified, no build step i
 ZOPEN_MAKE_OPTS      Options to pass to build program (defaults to '-j\${ZOPEN_NUM_JOBS}')
 ZOPEN_CHECK          Check program to run. If skip is specified, no check step is performed (defaults to '${ZOPEN_CHECKD}') 
 ZOPEN_CHECK_OPTS     Options to pass to check program (defaults to '${ZOPEN_CHECK_OPTSD}')
-ZOPEN_CHECK_OPTS     Options to pass to check program (defaults to '${ZOPEN_CHECK_OPTSD}')
 ZOPEN_IMAGE_REGISTRY Docker image registry to an OCI image to (use with --oci option)
 ZOPEN_IMAGE_DOCKERFILE_NAME Dockerfile name (default: Dockerfile)
 ZOPEN_IMAGE_DOCKER_NAME Docker/podman tool name (default: podman)

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -2,7 +2,6 @@
 #
 # General purpose build script for ZOSOpenTools ports
 #
-# ZOPEN_ROOT must be defined to the root directory of the cloned ZOSOpenTools port
 # ZOPEN_TYPE must be defined to either TARBALL or GIT. This indicates the type of package to build
 #
 # For more details, see the help which you can get by issuing:
@@ -12,15 +11,9 @@
 # Functions section
 #
 
-# Temporary files:
-temp_c_file="/tmp/$LOGNAME.$RANDOM.c"
-
-trap "/bin/rm -rf $temp_c_file && exit" EXIT INT TERM QUIT HUP
-
 printEnvVar()
 {
   echo "\
-ZOPEN_ROOT           The directory the port repo was extracted into (defaults to current directory)
 ZOPEN_TYPE           The type of package to download. Valid types are TARBALL and GIT (required)
 ZOPEN_TARBALL_URL    The fully qualified URL that the tarball should be downloaded from (required if ZOPEN_TYPE=TARBALL)
 ZOPEN_TARBALL_DEPS   Space-delimited set of source packages this git package depends on to build (required if ZOPEN_TYPE=TARBALL)
@@ -50,6 +43,9 @@ ZOPEN_CONFIGURE_OPTS Options to pass to configuration program (defaults to '--pr
 ZOPEN_EXTRA_CONFIGURE_OPTS Extra configure options to pass to configuration program (defaults to '')
 ZOPEN_INSTALL_DIR    Installation directory to pass to configuration (defaults to '\${HOME}/zopen/prod/<pkg>')
 ZOPEN_MAKE           Build program to run. If skip is specified, no build step is performed (defaults to '${ZOPEN_MAKED}')
+ZOPEN_MAKE_OPTS      Options to pass to build program (defaults to '-j\${ZOPEN_NUM_JOBS}')
+ZOPEN_CHECK          Check program to run. If skip is specified, no check step is performed (defaults to '${ZOPEN_CHECKD}') 
+ZOPEN_CHECK_OPTS     Options to pass to check program (defaults to '${ZOPEN_CHECK_OPTSD}')
 ZOPEN_MAKE_OPTS      Options to pass to build program (defaults to '-j\${ZOPEN_NUM_JOBS}')
 ZOPEN_CHECK          Check program to run. If skip is specified, no check step is performed (defaults to '${ZOPEN_CHECKD}') 
 ZOPEN_CHECK_OPTS     Options to pass to check program (defaults to '${ZOPEN_CHECK_OPTSD}')
@@ -196,12 +192,7 @@ checkEnv()
   #
   printHeader "Checking environment configuration"
 
-  if [ "${ZOPEN_ROOT}x" = "x" ]; then
-    printError "ZOPEN_ROOT needs to be defined to the root directory of the tool being ported"
-  fi
-  if ! [ -d "${ZOPEN_ROOT}" ]; then
-    printError "ZOPEN_ROOT ${ZOPEN_ROOT} is not a directory"
-  fi
+  export ZOPEN_ROOT=$(cd "$(dirname "$buildEnvFile")"; pwd)
 
   if [ "${ZOPEN_TYPE}x" = "TARBALLx" ]; then
     if [ "${ZOPEN_TARBALL_URL}x" = "x" ]; then
@@ -226,7 +217,7 @@ checkEnv()
   if command -V "${ZOPEN_CHECK_RESULTS}" >/dev/null 2>&1; then
     export ZOPEN_CHECK_RESULTS="${ZOPEN_ROOT}/portchk.sh"
     if ! [ -x "${ZOPEN_CHECK_RESULTS}" ]; then
-      printError "${ZOPEN_CHECK_RESULTS} script needs to be provided to check the results. Exit with 0 for Green, 1 for Yellow, and 2 for Red"
+      printError "zopen_check_results script needs to be provided to check the results."
     fi
   fi
 
@@ -958,5 +949,3 @@ fi
 if ! install; then
   exit 4
 fi
-
-exit 0

--- a/bin/lib/zopen-generate
+++ b/bin/lib/zopen-generate
@@ -15,6 +15,8 @@ printSyntax()
 printHeader "Generate a zopen project"
 echo "* What is the project name?"
 name=$(getInput)
+echo "* Provided a description of the project:"
+description=$(getInput)
 echo "* Enter the ${name}'s Git location: (if none, press enter)"
 gitpath=$(getInput)
 echo "* Enter ${name}'s build dependencies for the Git source: (example: curl make)"
@@ -83,4 +85,21 @@ zopen_append_to_env()
   # echo extra envars here:
 }
 EOT
-printHeader "${name} project is ready!"
+printHeader "$buildenv created"
+
+cat <<EOT >> "${name}port/README.md"
+${name}
+
+${description}
+EOT
+printHeader "${name}port/README.md created"
+
+cat <<EOT >> "${name}port/cicd.groovy"
+node('linux')
+{
+  stage('Build') {
+    build job: 'Port-Pipeline', parameters: [string(name: 'PORT_GITHUB_REPO', value: 'https://github.com/ZOSOpenTools/${name}port.git'), string(name: 'PORT_DESCRIPTION', value: '${description}' )]
+  }
+}
+EOT
+printHeader "${name} project is ready! Contact Mike Fulton (fultonm@ca.ibm.com) to create https://github.com/ZOSOpenTools/${name}port.git"

--- a/bin/lib/zopen-generate
+++ b/bin/lib/zopen-generate
@@ -1,0 +1,86 @@
+#!/bin/sh
+# Generates a zopen compatible project
+
+export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
+
+. "${utildir}/common.inc"
+
+printSyntax() 
+{
+  args=$*
+  echo "zopen-generate will generate a zopen compatible project" >&2
+  echo "Syntax: zopen-generate" >&2
+}
+
+printHeader "Generate a zopen project"
+echo "* What is the project name?"
+name=$(getInput)
+echo "* Enter the ${name}'s Git location: (if none, press enter)"
+gitpath=$(getInput)
+echo "* Enter ${name}'s build dependencies for the Git source: (example: curl make)"
+gitdeps=$(getInput)
+echo "* Enter the ${name}'s Tarball location? (if none, press enter)"
+tarpath=$(getInput)
+echo "* Enter ${name}'s build dependencies for the Tar source: (example: curl make)"
+tardeps=$(getInput)
+echo "* Enter the default build type: (tar or git)"
+buildtype=$(getInput)
+
+project_path="${name}port"
+
+if [ -d $project_path ]; then
+  echo "Directory $project_path already exists. Clobber it? (y, n)"
+  clobber=$(getInput)
+  if [ "$clobber" = "y" ]; then
+    rm -rf $project_path
+  else
+    exit 0
+  fi
+fi
+
+printHeader "Generating $project_path zopen project"
+mkdir ${name}port
+
+buildenv="${name}port/buildenv"
+cat <<EOT >> $buildenv
+if ! [ -f ./buildenv]; then
+  echo "Need to source from the buildenv directory" >&2
+  return 0
+fi
+EOT
+
+if [ ! -z "$gitpath" ]; then
+  echo "export ZOPEN_GIT_URL=\"$gitpath\"" >> $buildenv
+fi
+if [ ! -z "$gitdeps" ]; then
+  echo "export ZOPEN_GIT_DEPS=\"$gitdeps\"" >> $buildenv
+fi
+
+if [ ! -z "$tarpath" ]; then
+  echo "export ZOPEN_TARBALL_URL=\"$tarpath\"" >> $buildenv
+fi
+if [ ! -z "$tardeps" ]; then
+  echo "export ZOPEN_TARBALL_DEPS=\"$tardeps\"" >> $buildenv
+fi
+
+if [ ! -z "$buildtype" ] && [ "$buildtype" = "git" ]; then
+  echo "export ZOPEN_TYPE=\"GIT\"" >> $buildenv
+else
+  echo "export ZOPEN_TYPE=\"TARBALL\"" >> $buildenv
+fi
+
+cat <<EOT >> $buildenv
+zopen_check_results()
+{
+  dir="\$1"
+  pfx="\$2"
+  chk="\$1/\$2_check.log"
+  grep "All tests passed"
+}
+
+zopen_append_to_env()
+{
+  # echo extra envars here:
+}
+EOT
+printHeader "${name} project is ready!"

--- a/bin/zopen
+++ b/bin/zopen
@@ -19,6 +19,8 @@ printSyntax()
   echo " zopen build -v # Build port" >&2
   echo " # Download binaries from Github" >&2
   echo " zopen download" >&2
+  echo " # Generate a zopen template project" >&2
+  echo " zopen generate" >&2
 }
 
 export bindir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"

--- a/bin/zopen
+++ b/bin/zopen
@@ -12,6 +12,7 @@ printSyntax()
   echo "where <command> may be one of the following:" >&2
   echo " build: invokes the build script." >&2
   echo " download: downloads binaries" >&2
+  echo " generate: generate a zopen project" >&2
   echo "" >&2
   echo "Example usage:" >&2
   echo " # Build a port" >&2
@@ -33,6 +34,10 @@ while [[ $# -gt 0 ]]; do
     "download")
       shift
       exec "${bindir}/lib/zopen-download" $@
+      ;;
+    "generate")
+      shift
+      exec "${bindir}/lib/zopen-generate" $@
       ;;
     "help" | "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
       printSyntax "${args}"


### PR DESCRIPTION
* Adds a default .env file and check for the existence of bin/lib
* Allows the user to append .env entries via zopen_append_to_env
* Generates a `build.status` file based on check results return code.
* Allows the user to define the `zopen_check_results` command in buildenv, where the following return code mean:
   - 0 - Green - All tests passed
    - 1 - Blue - Most tests passed
    - 2 - Yellow - Most tests failed
    - 3 - Red - All tests failed or check is broken
    - 4 - Unknown - Skipped or something went wrong
 * Adds a generate script to generate a zopen project
* Removes the need to set ZOPEN_ROOT
* Adds a `zopen_post_install` hook - useful if we want to remove hardcoded prefix entries

Example modification to zotsampleport's buildenv:
```
zopen_check_results()
{
  dir="$1"
  pfx="$2"
  chk="$1/$2_check.log"
  echo "dir: $chk"

  grep 'All tests passed' "${chk}"
}

zopen_append_to_env()
{
  echo "export ZOT_ROOT=\${PWD}"
}

zopen_post_install()
{
  echo "In Post Install - Install dir: $1"
}
```

Before merging this in, we need to remove the portcrtenv.sh scripts and update buildenv for each port