### PR TITLE
without the 'return' files that might be 1047 from previous runs can …

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -584,6 +584,7 @@ applyPatches()
   if [ "${results}" != '' ]; then
     printInfo "Existing Changes are active in ${code_dir}."
     printInfo "To re-apply patches, perform a git reset on ${code_dir} prior to running applyPatches again."
+    return 0
   else
     for patch in $patches; do
       p="${patch_dir}/${patch}"


### PR DESCRIPTION
…get corrupted with the tag that follows