### PR TITLE
Allow ZOPEN_ROOT to be referenced in buildenv + Use variables for test return codes

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -209,8 +209,6 @@ checkEnv()
   #
   printHeader "Checking environment configuration"
 
-  export ZOPEN_ROOT=$(cd "$(dirname "$buildEnvFile")"; pwd)
-
   if [ "${ZOPEN_TYPE}x" = "TARBALLx" ]; then
     if [ "${ZOPEN_TARBALL_URL}x" = "x" ]; then
       export ZOPEN_TARBALL_URL="${ZOPEN_URL}"
@@ -848,7 +846,7 @@ resolveCommands()
     unset ZOPEN_MAKE_CMD
   fi
 
-  if [ "${ZOPEN_CHECK}x" != "skipx" ] && [ ! -z "$(command -v ${ZOPEN_CHECK})" ] && ! ${skipcheck}; then
+  if [ "${ZOPEN_CHECK}x" != "skipx" ] && [ ! -z "$(command -V ${ZOPEN_CHECK})" ] && ! ${skipcheck}; then
     export ZOPEN_CHECK_CMD="\"${ZOPEN_CHECK}\" ${ZOPEN_CHECK_OPTS} CC=${CC} \"CPPFLAGS=${CPPFLAGS}\" \"CFLAGS=${CFLAGS}\" CXX=${CXX} \"CXXFLAGS=${CXXFLAGS}\" \"LDFLAGS=${LDFLAGS}\""
     export ZOPEN_CHECK_RESULTS_CMD="\"${ZOPEN_CHECK_RESULTS}\" \"${ZOPEN_ROOT}/${dir}\" \"${LOG_PFX}\""
   else
@@ -945,6 +943,8 @@ fi
 if ! processOptions $*; then
   exit 4
 fi
+
+export ZOPEN_ROOT=$(cd "$(dirname "$buildEnvFile")"; pwd)
 
 if ! loadBuildEnv; then
   exit 4

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -728,11 +728,12 @@ check()
     printHeader "Skipping Check"
   fi
   case "$results" in
-    $ZOPEN_TEST_STATUS_ALL_PASSED) ZOPEN_STATUS="Green" ;; # All tests passed
-    $ZOPEN_TEST_STATUS_MOST_PASSED) ZOPEN_STATUS="Blue" ;; # Most tests passed
-    $ZOPEN_TEST_STATUS_SOME_PASSED) ZOPEN_STATUS="Yellow" ;; # Most tests failed
-    $ZOPEN_TEST_STATUS_NONE_PASSED) ZOPEN_STATUS="Red" ;; # Pretty much non-functional
-    $ZOPEN_TEST_STATUS_ERROR) ZOPEN_STATUS="Error" ;; # Skipped or bad return code from check results
+    $ZOPEN_TEST_STATUS_ALL_PASSED) ZOPEN_STATUS="Green (all tests passed)" ;; # All tests passed
+    $ZOPEN_TEST_STATUS_MOST_PASSED) ZOPEN_STATUS="Blue (most tests passed)" ;; # Most tests passed
+    $ZOPEN_TEST_STATUS_SOME_PASSED) ZOPEN_STATUS="Yellow (most tests failed)" ;; # Most tests failed
+    $ZOPEN_TEST_STATUS_NONE_PASSED) ZOPEN_STATUS="Red (all tests failed)" ;; # Pretty much non-functional
+    $ZOPEN_TEST_STATUS_ERROR) ZOPEN_STATUS="Error (could not run tests)" ;; # bad return code from check results
+    $ZOPEN_TEST_STATUS_SKIPPED) ZOPEN_STATUS="Skipped (tests skipped)" ;; # Skipped tests
   esac
 }
 
@@ -796,8 +797,10 @@ install()
     replaceHardcodedPaths
 
     # Store test.status into installed dir and build dir for cicd
+    touch "${ZOPEN_INSTALL_DIR}/test.status"
+    chtag -tc 819 "${ZOPEN_INSTALL_DIR}/test.status"
     echo "$ZOPEN_STATUS" > "${ZOPEN_INSTALL_DIR}/test.status"
-    echo "$ZOPEN_STATUS" > "test.status"
+    cp "${ZOPEN_INSTALL_DIR}/test.status" "test.status"
 
     if command -V "zopen_post_install" >/dev/null 2>&1; then
       printVerbose "Running zopen_post_install"

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -102,6 +102,12 @@ setDefaults()
   if [ -z "$ZOPEN_IMAGE_DOCKER_NAME" ]; then
     export ZOPEN_IMAGE_DOCKER_NAME="podman"
   fi
+  export ZOPEN_TEST_STATUS_ALL_PASSED=0
+  export ZOPEN_TEST_STATUS_MOST_PASSED=1
+  export ZOPEN_TEST_STATUS_SOME_PASSED=2
+  export ZOPEN_TEST_STATUS_NONE_PASSED=3
+  export ZOPEN_TEST_STATUS_ERROR=4
+  export ZOPEN_TEST_STATUS_SKIPPED=5
 }
 
 printSyntax()
@@ -709,7 +715,7 @@ build()
 check()
 {
   checklog="${LOG_PFX}_check.log"
-  results=4 # Unknown results
+  results=$ZOPEN_TEST_STATUS_SKIPPED # skipped
   if [ -n "${ZOPEN_CHECK_CMD}" ]; then
     printHeader "Running Check"
     create_fifo_pipe "${checklog}"
@@ -722,11 +728,11 @@ check()
     printHeader "Skipping Check"
   fi
   case "$results" in
-    0) ZOPEN_STATUS="Green" ;; # All tests passed
-    1) ZOPEN_STATUS="Blue" ;; # Most tests passed
-    2) ZOPEN_STATUS="Yellow" ;; # Most tests failed
-    3) ZOPEN_STATUS="Red" ;; # Pretty much non-functional
-    *) ZOPEN_STATUS="Unknown" ;; # Skipped or bad return code from check results
+    $ZOPEN_TEST_STATUS_ALL_PASSED) ZOPEN_STATUS="Green" ;; # All tests passed
+    $ZOPEN_TEST_STATUS_MOST_PASSED) ZOPEN_STATUS="Blue" ;; # Most tests passed
+    $ZOPEN_TEST_STATUS_SOME_PASSED) ZOPEN_STATUS="Yellow" ;; # Most tests failed
+    $ZOPEN_TEST_STATUS_NONE_PASSED) ZOPEN_STATUS="Red" ;; # Pretty much non-functional
+    $ZOPEN_TEST_STATUS_ERROR) ZOPEN_STATUS="Error" ;; # Skipped or bad return code from check results
   esac
 }
 
@@ -788,7 +794,11 @@ install()
     fi
     createEnv
     replaceHardcodedPaths
-    echo "$ZOPEN_STATUS" > "${ZOPEN_INSTALL_DIR}/build.status"
+
+    # Store test.status into installed dir and build dir for cicd
+    echo "$ZOPEN_STATUS" > "${ZOPEN_INSTALL_DIR}/test.status"
+    echo "$ZOPEN_STATUS" > "test.status"
+
     if command -V "zopen_post_install" >/dev/null 2>&1; then
       printVerbose "Running zopen_post_install"
       zopen_post_install ${ZOPEN_INSTALL_DIR}


### PR DESCRIPTION
* This is needed for makeport which references ZOPEN_ROOT