### PR TITLE
Test infrastructure changes + zopen generate updates + envar updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ The `buildenv` file _must_ set the following environment variables:
 - `ZOPEN_URL`: the URL where the source should be pulled from, including the `package.git` or `package-V.R.M.tar.gz` extension
 - `ZOPEN_DEPS`: a space-separated list of all software dependencies this package has.
 
-To help guage the health of the port, a `zopen_check_results()` function can be provided inside the buildenv. The following return codes map to a given status:
-- 0 - Green - All tests passed
-- 1 - Blue - Most tests passed
-- 2 - Yellow - Most tests failed
-- 3 - Red - All tests failed or check is broken
-- 4 - Unknown - Skipped or something went wrong
+To help guage the health of the port, a `zopen_check_results()` function can be provided inside the buildenv. This function should process
+the test results and emit a report of the failures vs total number of tests to stdout as in the following format:
+```
+failures=# count failures
+totalTests=# count total tests
+echo "$failures|$totalTests"
+```
 
 `zopen build` will generate a .env file in the install location with support for environment variables such as PATH, LIBPATH, and MANPATH.
 To add your own, you can append environment variables by echo'ing them in a function called `zopen_append_to_env()`.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ The `buildenv` file _must_ set the following environment variables:
 - `ZOPEN_DEPS`: a space-separated list of all software dependencies this package has.
 
 To help guage the health of the port, a `zopen_check_results()` function can be provided inside the buildenv. This function should process
-the test results and emit a report of the failures vs total number of tests to stdout as in the following format:
+the test results and emit a report of the failures vs total number of tests to stdout as in the following format: failures|totalTests.
+
+Example:
 ```
 failures=# count failures
 totalTests=# count total tests

--- a/bin/lib/common.inc
+++ b/bin/lib/common.inc
@@ -24,12 +24,18 @@ defineColors()
 
 defineEnvironment()
 {
+  # Required for proper operation of z/OS auto-conversion support
   export _BPXK_AUTOCVT=ON
   export _CEE_RUNOPTS="$_CEE_RUNOPTS FILETAG(AUTOCVT,AUTOTAG) POSIX(ON)"
   export _TAG_REDIR_ERR=txt
   export _TAG_REDIR_IN=txt
   export _TAG_REDIR_OUT=txt
+
+  # Required for proper operation of xlclang
   export _C89_CCMODE=1
+
+  # Required for proper operation of (USS shipped) sed
+  export _UNIX03=YES
 }
 
 zopenInitialize()

--- a/bin/lib/common.inc
+++ b/bin/lib/common.inc
@@ -41,13 +41,13 @@ zopenInitialize()
 printVerbose()
 {
   if ${verbose}; then
-    printf "${NC}${GREEN}${BOLD}VERBOSE${NC}: '${1}'\n" >&2
+    echo "${NC}${GREEN}${BOLD}VERBOSE${NC}: '${1}'" >&2
   fi
 }
 
 printHeader()
 {
-  printf "${NC}${UNDERLINE}${1}...${NC}\n" >&2
+  echo "${NC}${UNDERLINE}${1}...${NC}" >&2
 }
 
 runAndLog()
@@ -63,7 +63,7 @@ runAndLog()
 
 printSoftError()
 {
-  printf "${NC}${RED}${BOLD}***ERROR: ${NC}${RED}${1}${NC}\n" >&2
+  echo "${NC}${RED}${BOLD}***ERROR: ${NC}${RED}${1}${NC}" >&2
 }
 
 printError()
@@ -74,12 +74,12 @@ printError()
 
 printWarning()
 {
-  printf "${NC}${YELLOW}${BOLD}***WARNING: ${NC}${YELLOW}${1}${NC}\n" >&2
+  echo "${NC}${YELLOW}${BOLD}***WARNING: ${NC}${YELLOW}${1}${NC}" >&2
 }
 
 printInfo()
 {
-  printf "$1\n" >&2
+  echo "$1" >&2
 }
 
 getInput()

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -46,7 +46,6 @@ ZOPEN_MAKE           Build program to run. If skip is specified, no build step i
 ZOPEN_MAKE_OPTS      Options to pass to build program (defaults to '-j\${ZOPEN_NUM_JOBS}')
 ZOPEN_CHECK          Check program to run. If skip is specified, no check step is performed (defaults to '${ZOPEN_CHECKD}') 
 ZOPEN_CHECK_OPTS     Options to pass to check program (defaults to '${ZOPEN_CHECK_OPTSD}')
-ZOPEN_EXPECTED_FAILURES Number of expected failures. If the failures is greater than this number, fail. If not set, ignore.
 ZOPEN_IMAGE_REGISTRY Docker image registry to an OCI image to (use with --oci option)
 ZOPEN_IMAGE_DOCKERFILE_NAME Dockerfile name (default: Dockerfile)
 ZOPEN_IMAGE_DOCKER_NAME Docker/podman tool name (default: podman)
@@ -309,18 +308,26 @@ setDepsEnv()
 setEnv()
 {
   if [ "${CPPFLAGS}x" = "x" ]; then
-    export CPPFLAGS="${ZOPEN_CPPFLAGSD} ${ZOPEN_EXTRA_CPPFLAGS}"
+    export CPPFLAGS="${ZOPEN_CPPFLAGSD}" 
   fi
+  export CPPFLAGS="${CPPFLAGS} ${ZOPEN_EXTRA_CPPFLAGS}"
+
   if [ "${CC}x" = "x" ]; then
     export CC="${ZOPEN_CCD}"
-    export CFLAGS="${ZOPEN_CFLAGSD}"
-    export CFLAGS="${ZOPEN_CFLAGSD} ${ZOPEN_EXTRA_CFLAGS}"
   fi
+  if [ "${CFLAGS}x" = "x" ]; then
+    export CFLAGS="${ZOPEN_CFLAGSD}"
+  fi
+  export CFLAGS="${CFLAGS} ${ZOPEN_EXTRA_CFLAGS}"
 
   if [ "${CXX}x" = "x" ]; then
     export CXX="${ZOPEN_CXXD}"
-    export CXXFLAGS="${ZOPEN_CXXFLAGSD} ${ZOPEN_EXTRA_CXXFLAGS}"
   fi
+
+  if [ "${CXXFLAGS}x" = "x" ]; then
+    export CXXFLAGS="${ZOPEN_CXXFLAGSD}"
+  fi
+  export CXXFLAGS="${CXXFLAGS} ${ZOPEN_EXTRA_CXXFLAGS}"
 
   if [ "${CC}x" = "xlclangx" ]; then
     # Confirm xlclang is at least 1.0.0 (aka __COMPILER_VER__=42040001)
@@ -723,8 +730,22 @@ check()
     runAndLog "${ZOPEN_CHECK_CMD} > $TMP_FIFO_PIPE"
     if command -V "${ZOPEN_CHECK_RESULTS}" >/dev/null 2>&1; then
       testStatus="$(${ZOPEN_CHECK_RESULTS} "${ZOPEN_ROOT}/${dir}" "${LOG_PFX}")"
-      failures="$(echo $testStatus | cut -f1 -d'|' | tr -d ' ')"
-      totalTests="$(echo $testStatus | cut -f2 -d'|' | tr -d ' ')"
+      if echo "$testStatus" | grep -q "actualFailures:"; then
+        failures=$(echo "$testStatus" | grep "actualFailures:" | sed -e "s/.*actualFailures://" | tr -d ' ')
+      else
+        printError "${ZOPEN_CHECK_RESULTS} needs to emit an actualFailures:<number> line"
+      fi
+      if echo "$testStatus" | grep -q "expectedFailures:"; then
+        expected=$(echo "$testStatus" | grep "expectedFailures:" | sed -e "s/.*expectedFailures://" | tr -d ' ')
+        echo "EXPECTED: $expected"
+      else
+        printError "${ZOPEN_CHECK_RESULTS} needs to emit an expectedFailures:<number> line"
+      fi
+      if echo "$testStatus" | grep -q "totalTests:"; then
+        totalTests=$(echo "$testStatus" | grep "totalTests:" | sed -e "s/.*totalTests://" | tr -d ' ')
+      else
+        printError "${ZOPEN_CHECK_RESULTS} needs to emit an totalTests:<number> line"
+      fi
       success="$((totalTests-failures))"
       percent=$(awk "BEGIN { pc=100*${success}/${totalTests}; i=int(pc); print (pc-i<0.5)?i:i+1 }")
       summary="$success tests pass out of $totalTests tests - ${percent}% success rate"
@@ -747,12 +768,10 @@ check()
           ZOPEN_STATUS="Yellow ($summary)" # Most tests failed
         fi
       fi
-    fi
-    if [ ! -z "${ZOPEN_EXPECTED_FAILURES}" ]; then
-      if [ $failures -le $ZOPEN_EXPECTED_FAILURES ]; then
+      if [ $failures -le $expected ]; then
         return 0
       else
-        printError "Failures ($failures) not less than than \$ZOPEN_EXPECTED_FAILURES ($ZOPEN_EXPECTED_FAILURES). Failing...";
+        printError "Failures ($failures) not less than than expected ($expected). Failing...";
       fi
     fi
   else

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -46,7 +46,7 @@ ZOPEN_MAKE           Build program to run. If skip is specified, no build step i
 ZOPEN_MAKE_OPTS      Options to pass to build program (defaults to '-j\${ZOPEN_NUM_JOBS}')
 ZOPEN_CHECK          Check program to run. If skip is specified, no check step is performed (defaults to '${ZOPEN_CHECKD}') 
 ZOPEN_CHECK_OPTS     Options to pass to check program (defaults to '${ZOPEN_CHECK_OPTSD}')
-ZOPEN_EXPECTED_FAILURES Number of expected faiures. If the failures is greater than this number, fail. If not set, ignore.
+ZOPEN_EXPECTED_FAILURES Number of expected failures. If the failures is greater than this number, fail. If not set, ignore.
 ZOPEN_IMAGE_REGISTRY Docker image registry to an OCI image to (use with --oci option)
 ZOPEN_IMAGE_DOCKERFILE_NAME Dockerfile name (default: Dockerfile)
 ZOPEN_IMAGE_DOCKER_NAME Docker/podman tool name (default: podman)

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -722,9 +722,9 @@ check()
     create_fifo_pipe "${checklog}"
     runAndLog "${ZOPEN_CHECK_CMD} > $TMP_FIFO_PIPE"
     if command -V "${ZOPEN_CHECK_RESULTS}" >/dev/null 2>&1; then
-      testStatus="$(${ZOPEN_CHECK_RESULTS} \"${ZOPEN_ROOT}/${dir}\" \"${LOG_PFX}\")"
-      failures="$(echo $testStatus | cut -f1 -d'|')"
-      totalTests="$(echo $testStatus | cut -f2 -d'|')"
+      testStatus="$(${ZOPEN_CHECK_RESULTS} "${ZOPEN_ROOT}/${dir}" "${LOG_PFX}")"
+      failures="$(echo $testStatus | cut -f1 -d'|' | tr -d ' ')"
+      totalTests="$(echo $testStatus | cut -f2 -d'|' | tr -d ' ')"
       success="$((totalTests-failures))"
       percent=$(awk "BEGIN { pc=100*${success}/${totalTests}; i=int(pc); print (pc-i<0.5)?i:i+1 }")
       summary="$success tests pass out of $totalTests tests - ${percent}% success rate"

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -46,6 +46,7 @@ ZOPEN_MAKE           Build program to run. If skip is specified, no build step i
 ZOPEN_MAKE_OPTS      Options to pass to build program (defaults to '-j\${ZOPEN_NUM_JOBS}')
 ZOPEN_CHECK          Check program to run. If skip is specified, no check step is performed (defaults to '${ZOPEN_CHECKD}') 
 ZOPEN_CHECK_OPTS     Options to pass to check program (defaults to '${ZOPEN_CHECK_OPTSD}')
+ZOPEN_EXPECTED_FAILURES Number of expected faiures. If the failures is greater than this number, fail. If not set, ignore.
 ZOPEN_IMAGE_REGISTRY Docker image registry to an OCI image to (use with --oci option)
 ZOPEN_IMAGE_DOCKERFILE_NAME Dockerfile name (default: Dockerfile)
 ZOPEN_IMAGE_DOCKER_NAME Docker/podman tool name (default: podman)
@@ -721,20 +722,43 @@ check()
     create_fifo_pipe "${checklog}"
     runAndLog "${ZOPEN_CHECK_CMD} > $TMP_FIFO_PIPE"
     if command -V "${ZOPEN_CHECK_RESULTS}" >/dev/null 2>&1; then
-      ${ZOPEN_CHECK_RESULTS} "${ZOPEN_ROOT}/${dir}" "${LOG_PFX}"
-      results=$?
+      testStatus="$(${ZOPEN_CHECK_RESULTS} \"${ZOPEN_ROOT}/${dir}\" \"${LOG_PFX}\")"
+      failures="$(echo $testStatus | cut -f1 -d'|')"
+      totalTests="$(echo $testStatus | cut -f2 -d'|')"
+      success="$((totalTests-failures))"
+      percent=$(awk "BEGIN { pc=100*${success}/${totalTests}; i=int(pc); print (pc-i<0.5)?i:i+1 }")
+      summary="$success tests pass out of $totalTests tests - ${percent}% success rate"
+      printVerbose "Test results: $summary"
+      if ! [ $percent -eq $percent ]; then # not a number
+        results=$ZOPEN_TEST_STATUS_ERROR
+        ZOPEN_STATUS="Error (could not run tests)" # bad return code from check results
+      else
+        if [ $percent -eq 100 ]; then
+          results=$ZOPEN_TEST_STATUS_ALL_PASSED
+          ZOPEN_STATUS="Green ($summary)" # All tests passed
+        elif [ $percent -ge 50 ]; then
+          results=$ZOPEN_TEST_STATUS_MOST_PASSED
+          ZOPEN_STATUS="Blue ($summary)" # Most tests passed
+        elif [ $percent -eq 0 ]; then
+          results=$ZOPEN_TEST_STATUS_NONE_PASSED
+          ZOPEN_STATUS="Red ($summary)" # Pretty much non-functional
+        elif [ $percent -lt 50 ]; then
+          results=$ZOPEN_TEST_STATUS_SOME_PASSED
+          ZOPEN_STATUS="Yellow ($summary)" # Most tests failed
+        fi
+      fi
+    fi
+    if [ ! -z "${ZOPEN_EXPECTED_FAILURES}" ]; then
+      if [ $failures -le $ZOPEN_EXPECTED_FAILURES ]; then
+        return 0
+      else
+        printError "Failures ($failures) not less than than \$ZOPEN_EXPECTED_FAILURES ($ZOPEN_EXPECTED_FAILURES). Failing...";
+      fi
     fi
   else
     printHeader "Skipping Check"
+    ZOPEN_STATUS="Skipped (tests skipped)" # Skipped tests
   fi
-  case "$results" in
-    $ZOPEN_TEST_STATUS_ALL_PASSED) ZOPEN_STATUS="Green (all tests passed)" ;; # All tests passed
-    $ZOPEN_TEST_STATUS_MOST_PASSED) ZOPEN_STATUS="Blue (most tests passed)" ;; # Most tests passed
-    $ZOPEN_TEST_STATUS_SOME_PASSED) ZOPEN_STATUS="Yellow (most tests failed)" ;; # Most tests failed
-    $ZOPEN_TEST_STATUS_NONE_PASSED) ZOPEN_STATUS="Red (all tests failed)" ;; # Pretty much non-functional
-    $ZOPEN_TEST_STATUS_ERROR) ZOPEN_STATUS="Error (could not run tests)" ;; # bad return code from check results
-    $ZOPEN_TEST_STATUS_SKIPPED) ZOPEN_STATUS="Skipped (tests skipped)" ;; # Skipped tests
-  esac
 }
 
 replaceHardcodedPaths()

--- a/bin/lib/zopen-download
+++ b/bin/lib/zopen-download
@@ -9,14 +9,19 @@ printSyntax()
 {
   args=$*
   echo "zopen-download is a tool that downloads and extracts the latest z/OS Open Tools releases from GitHub Releases." >&2
+  echo "If you have a Github OAUTH token, export the environment variable ZOPEN_GIT_OAUTH_TOKEN" >&2
   echo "Syntax: zopen-download [<option>]*" >&2
   echo "  where <option> may be one or more of:" >&2
+  echo "  --list: list all available z/OS Open Tools"  >&2
+#TODO: future option
+#  echo "  --filter <color>: filter based on quality (green - all tests passing, blue - most tests passing, yellow - some tests passing, red - no tests passing, none (default))"  >&2
   echo "  -d <dir>: directory to download binaries to.  Uses current working directory if not specified." >&2
   echo "  -r <repo>: specific repo name to download. Downloads all ZOSOpenTools if not specified." >&2
 }
 
 args=$*
 download=$PWD
+filter=none
 while [[ $# -gt 0 ]]; do
   case "$1" in
     "-d")
@@ -29,6 +34,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     "--list")
       list=1;
+      ;;
+    "--filter")
+      filter=$2;
       ;;
     "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
       printSyntax "${args}"
@@ -49,11 +57,21 @@ if [ ! -z "${download}" -a -d "${download}" ]; then
   cd "${download}"
 fi
 
-#FIXME: Once jq is ported, rewrite with jq
-if ! repo_results=$(curl -k -s "https://api.github.com/users/ZOSOpenTools/repos?per_page=100" 2>/dev/null | grep "\"full_name\":" | cut -d '"' -f 4); then
-  printError "curl command could not download the z/OS Open Tools repository list"
+if [ ! -z "${ZOPEN_GIT_OAUTH_TOKEN}" ]; then
+  OAUTH_TOKEN_OPTION='-H'
+  OAUTH_TOKEN="Authorization: Bearer ${ZOPEN_GIT_OAUTH_TOKEN}" 
 fi
 
+if ! repo_results=$(curl $OAUTH_TOKEN_OPTION "$OAUTH_TOKEN" -k -s "https://api.github.com/users/ZOSOpenTools/repos?per_page=100"); then
+  printError "curl command could not download the z/OS Open Tools repository list"
+fi
+repo_results=$(echo "$repo_results" | grep "\"full_name\":" | cut -d '"' -f 4)
+
+if [ ! -z "$list" ]; then
+  printf "${NC}${UNDERLINE}${1}%-25s %-25s\n${NC}" "Repo" "Build Status"
+fi
+
+foundPort=false
 for repo in $(echo ${repo_results}); do
   repo=${repo#"ZOSOpenTools/"}
   if [ -z $toolrepo ] || [ "${toolrepo}" = "${repo}" ]; then
@@ -61,12 +79,17 @@ for repo in $(echo ${repo_results}); do
     if [ "${repo}" = "${name}" ]; then
       continue;
     fi
+    testStatus=$(curl $OAUTH_TOKEN_OPTION "$OAUTH_TOKEN" -k -s https://api.github.com/repos/ZOSOpenTools/${repo}/releases/latest | grep "\"body\":.*Test Status:" | sed -e "s#.*Test Status:<\/b>##" -e "s#[ ]*(.*##" | tr -d ' ')
+    if [ -z "$testStatus" ]; then
+      testStatus="Untested";
+    fi
     if [ ! -z "$list" ]; then
-      echo "$repo"
+      printf '%-25s %-25s\n' "$repo" "$testStatus"
       continue;
     fi
+    foundPort=true
     printHeader "Downloading latest release from $repo"
-    if ! latest_url=$(curl -k -s https://api.github.com/repos/ZOSOpenTools/${repo}/releases/latest 2>/dev/null | grep browser_download_url | cut -d '"' -f 4); then
+    if ! latest_url=$(curl $OAUTH_TOKEN_OPTION "$OAUTH_TOKEN" -k -s https://api.github.com/repos/ZOSOpenTools/${repo}/releases/latest | grep browser_download_url | cut -d '"' -f 4); then
       printError "Could not find the latest url for $repo"
     fi
 
@@ -99,3 +122,7 @@ for repo in $(echo ${repo_results}); do
     fi 
   fi
 done
+
+if ! $foundPort && test -z $list; then
+  printError "Could not find $toolrepo. Run with --list option to view the available ports"
+fi

--- a/bin/lib/zopen-generate
+++ b/bin/lib/zopen-generate
@@ -13,19 +13,19 @@ printSyntax()
 }
 
 printHeader "Generate a zopen project"
-echo "* What is the project name?"
+echo "What is the project name?"
 name=$(getInput)
-echo "* Provided a description of the project:"
+echo "Provided a description of the project:"
 description=$(getInput)
-echo "* Enter the ${name}'s Git location: (if none, press enter)"
+echo "Enter ${name}'s Git location: (if none, press enter)"
 gitpath=$(getInput)
-echo "* Enter ${name}'s build dependencies for the Git source: (example: curl make)"
+echo "Enter ${name}'s build dependencies for the Git source: (example: curl make)"
 gitdeps=$(getInput)
-echo "* Enter the ${name}'s Tarball location? (if none, press enter)"
+echo "Enter ${name}'s Tarball location? (if none, press enter)"
 tarpath=$(getInput)
-echo "* Enter ${name}'s build dependencies for the Tar source: (example: curl make)"
+echo "Enter ${name}'s build dependencies for the Tar source: (example: curl make)"
 tardeps=$(getInput)
-echo "* Enter the default build type: (tar or git)"
+echo "Enter the default build type: (tar or git)"
 buildtype=$(getInput)
 
 project_path="${name}port"
@@ -41,15 +41,9 @@ if [ -d $project_path ]; then
 fi
 
 printHeader "Generating $project_path zopen project"
-mkdir ${name}port
+mkdir -p ${name}port/patches
 
 buildenv="${name}port/buildenv"
-cat <<EOT >> $buildenv
-if ! [ -f ./buildenv]; then
-  echo "Need to source from the buildenv directory" >&2
-  return 0
-fi
-EOT
 
 if [ ! -z "$gitpath" ]; then
   echo "export ZOPEN_GIT_URL=\"$gitpath\"" >> $buildenv
@@ -77,22 +71,27 @@ zopen_check_results()
   dir="\$1"
   pfx="\$2"
   chk="\$1/\$2_check.log"
-  grep "All tests passed"
+
+  # Echo the following information to guage build health
+  echo "actualFailures:0"
+  echo "totalTests:1"
+  echo "expectedFailures:0"
+  
 }
 
 zopen_append_to_env()
 {
-  # echo extra envars here:
+  # echo envars outside of PATH, MANPATH, LIBPATH
 }
 EOT
-printHeader "$buildenv created"
+printInfo "$buildenv created"
 
 cat <<EOT >> "${name}port/README.md"
 ${name}
 
 ${description}
 EOT
-printHeader "${name}port/README.md created"
+printInfo "${name}port/README.md created"
 
 cat <<EOT >> "${name}port/cicd.groovy"
 node('linux')
@@ -102,4 +101,7 @@ node('linux')
   }
 }
 EOT
-printHeader "${name} project is ready! Contact Mike Fulton (fultonm@ca.ibm.com) to create https://github.com/ZOSOpenTools/${name}port.git"
+printHeader "${name} project is ready!"
+printInfo "Create patches under the ${name}port/patches directory"
+printInfo "Run zopen build to build ${name}port"
+printInfo "Contact Mike Fulton (fultonm@ca.ibm.com) to create https://github.com/ZOSOpenTools/${name}port.git"


### PR DESCRIPTION
* zopen_check_results() will now require the emitting to stdout of the count of failures over total tests.
* It requires the following format:
```
 cat <<ZZ
 actualFailures:$failures
 totalTests:$totalTests
 expectedFailures:4
ZZ
```
* Also adds _UNIX03=YES
* Updates zopen generate