### PR TITLE
Preserve attributes on unpax + don't rename .git + fix chtag errors for empty patch directory + --buildtype option + add details for zopen_check_results

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,22 +29,29 @@ zopen download -r makeport -d $HOME/zopen
 To build a software package, you can use `zopen build`.
 
 `zopen build` requires the files scripts in the project's root directory:
--  `buildenv`, which `zopen build` will automatically source.  If you would like to source another file, you can specify it via the `-e` option as in: `zopen build -e mybuildenv`
+- `buildenv`, which `zopen build` will automatically source.  If you would like to source another file, you can specify it via the `-e` option as in: `zopen build -e mybuildenv`
 
 The `buildenv` file _must_ set the following environment variables:
 - `ZOPEN_TYPE`: one of _TARBALL_ or _GIT_ indicating where the source should be pulled from (a source tarball or git repository)
 - `ZOPEN_URL`: the URL where the source should be pulled from, including the `package.git` or `package-V.R.M.tar.gz` extension
 - `ZOPEN_DEPS`: a space-separated list of all software dependencies this package has.
 
-To help guage the health of the port, a `zopen_check_results()` function can be provided inside the buildenv. This function should process
-the test results and emit a report of the failures vs total number of tests to stdout as in the following format: failures|totalTests.
+To help guage the build quality of the port, a `zopen_check_results()` function needs to be provided inside the buildenv. This function should process
+the test results and emit a report of the failures, total number of tests, and expected number of failures to stdout as in the following format: failures|totalTests.
 
 Example:
-```
+```bash
 failures=# count failures
 totalTests=# count total tests
-echo "$failures|$totalTests"
+
+cat <<ZZ
+actualFailures:$failures
+totalTests:$totalTests
+expectedFailures:0
+ZZ
 ```
+
+The build will fail to proceed to the install step if the expectedFailures is greater than the actual failures.
 
 `zopen build` will generate a .env file in the install location with support for environment variables such as PATH, LIBPATH, and MANPATH.
 To add your own, you can append environment variables by echo'ing them in a function called `zopen_append_to_env()`.

--- a/README.md
+++ b/README.md
@@ -37,21 +37,32 @@ The `buildenv` file _must_ set the following environment variables:
 - `ZOPEN_DEPS`: a space-separated list of all software dependencies this package has.
 
 To help guage the build quality of the port, a `zopen_check_results()` function needs to be provided inside the buildenv. This function should process
-the test results and emit a report of the failures, total number of tests, and expected number of failures to stdout as in the following format: failures|totalTests.
+the test results and emit a report of the failures, total number of tests, and expected number of failures to stdout as in the following format: 
+```
+actualFailures:<numberoffailures>
+totalTests:<totalnumberoftests>
+expectedFailures:<expectednumberoffailures>
+```
 
-Example:
+The build will fail to proceed to the install step if `expectedFailures` is greater than `actualFailures`.
+
+Here is an example implementation of `zopen_check_results()`:
+
 ```bash
-failures=# count failures
-totalTests=# count total tests
+zopen_check_results()
+{
+chk="$2_check.log"
+
+failures=$(grep ".* Test.*in .* Categories Failed" ${chk} | cut -f1 -d' ')
+totalTests=$(grep ".* Test.*in .* Categories Failed" ${chk} | cut -f5 -d' ')
 
 cat <<ZZ
 actualFailures:$failures
 totalTests:$totalTests
 expectedFailures:0
 ZZ
+}
 ```
-
-The build will fail to proceed to the install step if the expectedFailures is greater than the actual failures.
 
 `zopen build` will generate a .env file in the install location with support for environment variables such as PATH, LIBPATH, and MANPATH.
 To add your own, you can append environment variables by echo'ing them in a function called `zopen_append_to_env()`.

--- a/bin/lib/common.inc
+++ b/bin/lib/common.inc
@@ -67,6 +67,29 @@ runAndLog()
   return $rc
 }
 
+runInBackgroundWithTimeoutAndLog()
+{
+  command="$1"
+  printVerbose "$command"
+  eval "$command &"
+  timeout="$2"
+  PID=$!
+  n=0
+  while [ $n -le $timeout ]; do
+    kill -0 $PID 2>/dev/null
+    if [ $? != 0 ]; then
+      wait $PID
+      rc=$?
+      return $rc
+    else
+      sleep 1
+      n=`expr $n + 1`
+    fi
+  done
+  kill -9 $PID
+  printError "TIMEOUT: (PID: $PID): $command"
+}
+
 printSoftError()
 {
   echo "${NC}${RED}${BOLD}***ERROR: ${NC}${RED}${1}${NC}" >&2

--- a/bin/lib/common.inc
+++ b/bin/lib/common.inc
@@ -70,15 +70,19 @@ runAndLog()
 runInBackgroundWithTimeoutAndLog()
 {
   command="$1"
-  printVerbose "$command"
-  eval "$command &"
   timeout="$2"
+
+  printVerbose "$command with timeout of ${timeout}s"
+  eval "$command &; TEEPID=$!"
   PID=$!
   n=0
   while [ $n -le $timeout ]; do
     kill -0 $PID 2>/dev/null
     if [ $? != 0 ]; then
       wait $PID
+      if [ ! -z "${SSH_TTY}" ]; then
+        chtag -r $SSH_TTY
+      fi
       rc=$?
       return $rc
     else
@@ -87,6 +91,7 @@ runInBackgroundWithTimeoutAndLog()
     fi
   done
   kill -9 $PID
+  kill -9 $TEEPID
   printError "TIMEOUT: (PID: $PID): $command"
 }
 

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -46,6 +46,7 @@ ZOPEN_MAKE           Build program to run. If skip is specified, no build step i
 ZOPEN_MAKE_OPTS      Options to pass to build program (defaults to '-j\${ZOPEN_NUM_JOBS}')
 ZOPEN_CHECK          Check program to run. If skip is specified, no check step is performed (defaults to '${ZOPEN_CHECKD}') 
 ZOPEN_CHECK_OPTS     Options to pass to check program (defaults to '${ZOPEN_CHECK_OPTSD}')
+ZOPEN_CHECK_TIMEOUT  Timeout limit in seconds for the check program (defaults to '${ZOPEN_CHECK_TIMEOUTD}')
 ZOPEN_IMAGE_REGISTRY Docker image registry to an OCI image to (use with --oci option)
 ZOPEN_IMAGE_DOCKERFILE_NAME Dockerfile name (default: Dockerfile)
 ZOPEN_IMAGE_DOCKER_NAME Docker/podman tool name (default: podman)
@@ -94,6 +95,7 @@ setDefaults()
   export ZOPEN_MAKED="make"
   export ZOPEN_CHECKD="make"
   export ZOPEN_CHECK_OPTSD="check"
+  export ZOPEN_CHECK_TIMEOUTD="12600" # 3.5 hours
   export ZOPEN_INSTALLD="make"
   export ZOPEN_INSTALL_OPTSD="install"
   if [ -z "$ZOPEN_IMAGE_DOCKERFILE_NAME" ]; then
@@ -403,6 +405,9 @@ setEnv()
   fi
   if [ "${ZOPEN_CHECK}x" = "x" ]; then
     export ZOPEN_CHECK="${ZOPEN_CHECKD}"
+  fi
+  if [ "${ZOPEN_CHECK_TIMEOUT}x" = "x" ]; then
+    export ZOPEN_CHECK_TIMEOUT="${ZOPEN_CHECK_TIMEOUTD}"
   fi
   if [ "${ZOPEN_CHECK_OPTS}x" = "x" ]; then
     export ZOPEN_CHECK_OPTS="${ZOPEN_CHECK_OPTSD}"
@@ -732,7 +737,7 @@ check()
   if [ -n "${ZOPEN_CHECK_CMD}" ]; then
     printHeader "Running Check"
     create_fifo_pipe "${checklog}"
-    runInBackgroundWithTimeoutAndLog "${ZOPEN_CHECK_CMD} > $TMP_FIFO_PIPE" 12600 # 3.5 hour timeout 
+    runInBackgroundWithTimeoutAndLog "${ZOPEN_CHECK_CMD} > $TMP_FIFO_PIPE" "${ZOPEN_CHECK_TIMEOUT}"
     if command -V "${ZOPEN_CHECK_RESULTS}" >/dev/null 2>&1; then
       testStatus="$(${ZOPEN_CHECK_RESULTS} "${ZOPEN_ROOT}/${dir}" "${LOG_PFX}")"
       if echo "$testStatus" | grep -q "actualFailures:"; then

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -86,8 +86,8 @@ setDefaults()
   export ZOPEN_CCD="xlclang"
   export ZOPEN_CXXD="xlclang++"
   export ZOPEN_CPPFLAGSD="-DNSIG=9 -D_XOPEN_SOURCE=600 -D_ALL_SOURCE -D_OPEN_SYS_FILE_EXT=1 -D_AE_BIMODAL=1 -D_ENHANCED_ASCII_EXT=0xFFFFFFFF"
-  export ZOPEN_CFLAGSD="-qascii -std=gnu11"
-  export ZOPEN_CXXFLAGSD="-+ -qascii"
+  export ZOPEN_CFLAGSD="-qascii -std=gnu11 -qnocsect"
+  export ZOPEN_CXXFLAGSD="-+ -qascii -qnocsect"
   export ZOPEN_BOOTSTRAPD="./bootstrap"
   export ZOPEN_BOOTSTRAP_OPTSD=""
   export ZOPEN_CONFIGURED="./configure"
@@ -127,6 +127,7 @@ printSyntax()
   echo "  where <option> may be one or more of:" >&2
   echo "  -h: print this information" >&2
   echo "  -v: run in verbose mode" >&2
+  echo "  --buildtype: release|debug" >&2
   echo "  --oci: build and publish an OCI image to \$ZOPEN_IMAGE_REGISTRY" >&2
   echo "  -e <env file>: source <env file> instead of buildenv to establish build environment" >&2
   echo "  -s: exec a shell before running configure.  Useful when manually building ports." >&2
@@ -140,6 +141,7 @@ processOptions()
   verbose=false
   publishOCI=false
   skipcheck=false
+  buildInReleaseMode=false
   startShell=false
   buildEnvFile="./buildenv"
   depsPath="$HOME/zopen/prod|$HOME/zopen/boot|/usr/bin/zopen/"
@@ -151,6 +153,15 @@ processOptions()
         ;;
       "-v" | "--v" | "-verbose" | "--verbose")
         verbose=true
+        ;;
+      "-buildtype" | "--buildtype" | "-b")
+        shift
+        btype=$(echo "$1" | awk '{print toupper($0)}')
+        if [ "$btype" = "RELEASE" ]; then
+          buildInReleaseMode=true
+          ZOPEN_CFLAGSD="${ZOPEN_CFLAGSD} -O3";
+          ZOPEN_CXXFLAGSD="${ZOPEN_CXXFLAGSD} -O3";
+        fi
         ;;
       "-oci" | "--oci")
         publishOCI=true

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -732,7 +732,7 @@ check()
   if [ -n "${ZOPEN_CHECK_CMD}" ]; then
     printHeader "Running Check"
     create_fifo_pipe "${checklog}"
-    runAndLog "${ZOPEN_CHECK_CMD} > $TMP_FIFO_PIPE"
+    runInBackgroundWithTimeoutAndLog "${ZOPEN_CHECK_CMD} > $TMP_FIFO_PIPE" 12600 # 3.5 hour timeout 
     if command -V "${ZOPEN_CHECK_RESULTS}" >/dev/null 2>&1; then
       testStatus="$(${ZOPEN_CHECK_RESULTS} "${ZOPEN_ROOT}/${dir}" "${LOG_PFX}")"
       if echo "$testStatus" | grep -q "actualFailures:"; then

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -503,12 +503,6 @@ extractTarBall()
   if ! git init . >/dev/null || ! git add -f ${files} >/dev/null || ! git commit --allow-empty -m "Create Repository for patch management" >/dev/null; then
     printError "Unable to initialize git repository for tarball"
   fi
- 
-
-  # Having the directory git-managed exposes some problems in the current git for software like autoconf,
-  # so move .git to the side and just use it for applying patches
-  # (you will also need to move it back to do a 'git diff' on any new patches you want to develop)
-  mv .git .git-for-patches
 }
 
 downloadTarBall()
@@ -619,7 +613,7 @@ applyPatches()
   fi
 
   # Tag the files that were just updated (again) as ASCII (hopefully can remove after we build our own git)
-  (cd "${code_dir}" && git status --untracked-files -s | awk '{ $1=""; print; }' | xargs chtag -tcISO8859-1)
+  (cd "${code_dir}" && git status --untracked-files -s | awk '{ $1=""; print; }' | xargs -I {} chtag -tcISO8859-1)
   if ${moved}; then
     mv "${code_dir}/.git" "${code_dir}/.git-for-patches" || exit 99
   fi

--- a/bin/lib/zopen-download
+++ b/bin/lib/zopen-download
@@ -108,7 +108,7 @@ for repo in $(echo ${repo_results}); do
     fi
 
     printHeader "Extracting $pax"
-    if ! pax -rf $pax 2>/dev/null; then
+    if ! pax -rf $pax -p p 2>/dev/null; then
       printWarning "Could not extract $pax. Skipping"
       continue;
     fi


### PR DESCRIPTION
* Removed the rename of .git dir as I was able to build autoconf without having to rename .git-for-patches. 
* I noticed zopen download doesn't preserve some attributes, added -p p to resolve
* The xargs -I {} fixes the chtag warnings for an empty patch dir
* Also adds a --buildtype option which when set to release adds -O3. In the future, we could add other options/logic based on buildtype
* Also adds details about the zopen_check_results spec.
* Adds a timeout limit of 3.5 hours when running check, which can be overridden with ZOPEN_CHECK_TIMEOUT