### PR TITLE
Pass filenames with spaces to chtag

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -430,7 +430,7 @@ tagTree()
   dir="$1"
   absdir=$(cd ${dir} && echo "${PWD}")
   (cd "${absdir}" && find . -name "*.pdf" -o -name "*.png" -o -name "*.bat" ! -type d ! -type l | xargs -I {} chtag -b {})
-  (cd "${absdir}" && find . ! -type d ! -type l | xargs -I {} chtag -qp {} | awk '{ if ($1 == "-") { print $4; }}' | xargs -I {} chtag -tcISO8859-1 {})
+  (cd "${absdir}" && find . ! -type d ! -type l | xargs -I {} chtag -qp {} | awk '{ if ($1 == "-") { sub(/^[ ]*([^ ]+ +){3}/, ""); print $0; }}' | xargs -I {} chtag -tcISO8859-1 {})
 }
 
 gitClone()


### PR DESCRIPTION
Fixes #29 

The problem was that the awk command to filter the untagged files was only passing on the first part of the file name.
The updated awk matches the first 3 non-space sections on the line and removes them, returning everything from the 4th field onwards.