### PR TITLE
Add contributing.md file + fix tagging in zopen generate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,13 +18,16 @@ No pull request can be merged without being reviewed and approved.
 
 ## Validate your changes
 
-Verify that the project is working by running `zopen build`
+Verify that the project is working by running `zopen build`.
 
 ## Coding Guidelines
 
 When contributing your changes, please follow the following coding guidelines:
-* patches: patches should adhere to the coding guidelines from the original project repository
+* patches: patches should adhere to the coding guidelines from the original project repository. Make sure to add the original project's LICENSE file within the patches
+directory.
 * zopen framework files: (e.g. buildenv) - It is recommended that you follow the [Google Shell Style Guide](https://google.github.io/styleguide/shellguide.html)
+
+If you are generating a new project, we recommend that you use `zopen generate` to create the correct zopen file and directory structure.
 
 ### Commit message
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing
+
+## Issues
+
+Log an issue for any question or problem you might have. When in doubt, log an issue, and
+any additional policies about what to include will be provided in the responses. The only
+exception is security disclosures which should be sent privately.
+
+Committers may direct you to another repository, ask for additional clarifications, and
+add appropriate metadata before the issue is addressed.
+
+## Contributions
+
+Any change to resources in this repository must be through pull requests. This applies to all changes
+to documentation, code, binary files, etc.
+
+No pull request can be merged without being reviewed and approved.
+
+## Validate your changes
+
+Verify that the project is working by running `zopen build`
+
+## Coding Guidelines
+
+When contributing your changes, please follow the following coding guidelines:
+* patches: patches should adhere to the coding guidelines from the original project repository
+* zopen framework files: (e.g. buildenv) - It is recommended that you follow the [Google Shell Style Guide](https://google.github.io/styleguide/shellguide.html)
+
+### Commit message
+
+A good commit message should describe what changed and why.
+
+It should:
+  * contain a short description of the change
+  * be entirely in lowercase with the exception of proper nouns, acronyms, and the words that refer to code, like function/variable names
+  * be prefixed with one of the following words:
+    * fix: bug fix
+    * hotfix: urgent bug fix
+    * feat: new or updated feature
+    * docs: documentation updates
+    * refactor: code refactoring (no functional change)
+    * perf: performance improvement
+    * test: tests and CI updates
+
+### Developer's Certificate of Origin 1.1
+
+<pre>
+By making a contribution to this project, I certify that:
+
+ (a) The contribution was created in whole or in part by me and I
+     have the right to submit it under the open source license
+     indicated in the file; or
+
+ (b) The contribution is based upon previous work that, to the best
+     of my knowledge, is covered under an appropriate open source
+     license and I have the right under that license to submit that
+     work with modifications, whether created in whole or in part
+     by me, under the same open source license (unless I am
+     permitted to submit under a different license), as indicated
+     in the file; or
+
+ (c) The contribution was provided directly to me by some other
+     person who certified (a), (b) or (c) and I have not modified
+     it.
+
+ (d) I understand and agree that this project and the contribution
+     are public and that a record of the contribution (including all
+     personal information I submit with it, including my sign-off) is
+     maintained indefinitely and may be redistributed consistent with
+     this project or the open source license(s) involved.
+</pre>

--- a/bin/data/CONTRIBUTING.md
+++ b/bin/data/CONTRIBUTING.md
@@ -18,13 +18,16 @@ No pull request can be merged without being reviewed and approved.
 
 ## Validate your changes
 
-Verify that the project is working by running `zopen build`
+Verify that the project is working by running `zopen build`.
 
 ## Coding Guidelines
 
 When contributing your changes, please follow the following coding guidelines:
-* patches: patches should adhere to the coding guidelines from the original project repository
+* patches: patches should adhere to the coding guidelines from the original project repository. Make sure to add the original project's LICENSE file within the patches
+directory.
 * zopen framework files: (e.g. buildenv) - It is recommended that you follow the [Google Shell Style Guide](https://google.github.io/styleguide/shellguide.html)
+
+If you are generating a new project, we recommend that you use `zopen generate` to create the correct zopen file and directory structure.
 
 ### Commit message
 

--- a/bin/data/CONTRIBUTING.md
+++ b/bin/data/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing
+
+## Issues
+
+Log an issue for any question or problem you might have. When in doubt, log an issue, and
+any additional policies about what to include will be provided in the responses. The only
+exception is security disclosures which should be sent privately.
+
+Committers may direct you to another repository, ask for additional clarifications, and
+add appropriate metadata before the issue is addressed.
+
+## Contributions
+
+Any change to resources in this repository must be through pull requests. This applies to all changes
+to documentation, code, binary files, etc.
+
+No pull request can be merged without being reviewed and approved.
+
+## Validate your changes
+
+Verify that the project is working by running `zopen build`
+
+## Coding Guidelines
+
+When contributing your changes, please follow the following coding guidelines:
+* patches: patches should adhere to the coding guidelines from the original project repository
+* zopen framework files: (e.g. buildenv) - It is recommended that you follow the [Google Shell Style Guide](https://google.github.io/styleguide/shellguide.html)
+
+### Commit message
+
+A good commit message should describe what changed and why.
+
+It should:
+  * contain a short description of the change
+  * be entirely in lowercase with the exception of proper nouns, acronyms, and the words that refer to code, like function/variable names
+  * be prefixed with one of the following words:
+    * fix: bug fix
+    * hotfix: urgent bug fix
+    * feat: new or updated feature
+    * docs: documentation updates
+    * refactor: code refactoring (no functional change)
+    * perf: performance improvement
+    * test: tests and CI updates
+
+### Developer's Certificate of Origin 1.1
+
+<pre>
+By making a contribution to this project, I certify that:
+
+ (a) The contribution was created in whole or in part by me and I
+     have the right to submit it under the open source license
+     indicated in the file; or
+
+ (b) The contribution is based upon previous work that, to the best
+     of my knowledge, is covered under an appropriate open source
+     license and I have the right under that license to submit that
+     work with modifications, whether created in whole or in part
+     by me, under the same open source license (unless I am
+     permitted to submit under a different license), as indicated
+     in the file; or
+
+ (c) The contribution was provided directly to me by some other
+     person who certified (a), (b) or (c) and I have not modified
+     it.
+
+ (d) I understand and agree that this project and the contribution
+     are public and that a record of the contribution (including all
+     personal information I submit with it, including my sign-off) is
+     maintained indefinitely and may be redistributed consistent with
+     this project or the open source license(s) involved.
+</pre>

--- a/bin/lib/zopen-generate
+++ b/bin/lib/zopen-generate
@@ -74,56 +74,61 @@ mkdir -p ${name}port/patches
 echo "${licenseName}\nView license contents at ${licenseUrl}" > "${name}port/patches/LICENSE"
 
 buildenv="${name}port/buildenv"
+touch $buildenv && chtag -tc 819 $buildenv
+
+cp "${utildir}/../data/CONTRIBUTING.md" "${name}port/CONTRIBUTING.md"
 
 if [ ! -z "$gitpath" ]; then
-  echo "export ZOPEN_GIT_URL=\"$gitpath\"" >> $buildenv
+  buildenvContents="export ZOPEN_GIT_URL=\"$gitpath\"\n"
 fi
 if [ ! -z "$gitdeps" ]; then
-  echo "export ZOPEN_GIT_DEPS=\"$gitdeps\"" >> $buildenv
+  buildenvContents="${buildenvContents}export ZOPEN_GIT_DEPS=\"$gitdeps\"\n"
 fi
 
 if [ ! -z "$tarpath" ]; then
-  echo "export ZOPEN_TARBALL_URL=\"$tarpath\"" >> $buildenv
+  buildenvContents="${buildenvContents}export ZOPEN_TARBALL_URL=\"$tarpath\"\n"
 fi
 if [ ! -z "$tardeps" ]; then
-  echo "export ZOPEN_TARBALL_DEPS=\"$tardeps\"" >> $buildenv
+  buildenvContents="${buildenvContents}export ZOPEN_TARBALL_DEPS=\"$tardeps\"\n"
 fi
 
 if [ ! -z "$buildtype" ] && [ "$buildtype" = "git" ]; then
-  echo "export ZOPEN_TYPE=\"GIT\"" >> $buildenv
+  buildenvContents="${buildenvContents}export ZOPEN_TYPE=\"GIT\"\n"
 else
-  echo "export ZOPEN_TYPE=\"TARBALL\"" >> $buildenv
+  buildenvContents="${buildenvContents}export ZOPEN_TYPE=\"TARBALL\"\n"
 fi
 
-cat <<EOT >> $buildenv
-
-zopen_check_results()
+buildenvContents="${buildenvContents}\nzopen_check_results()
 {
-  dir="\$1"
-  pfx="\$2"
-  chk="\$1/\$2_check.log"
+  dir=\"\$1\"
+  pfx=\"\$2\"
+  chk=\"\$1/\$2_check.log\"
 
   # Echo the following information to guage build health
-  echo "actualFailures:0"
-  echo "totalTests:1"
-  echo "expectedFailures:0"
+  echo \"actualFailures:0\"
+  echo \"totalTests:1\"
+  echo \"expectedFailures:0\"
 }
 
 zopen_append_to_env()
 {
   # echo envars outside of PATH, MANPATH, LIBPATH
-}
-EOT
+}"
+
+echo "$buildenvContents" > $buildenv
+
 printInfo "$buildenv created"
 
-cat <<EOT >> "${name}port/README.md"
+touch "${name}port/README.md" && chtag -tc 819 "${name}port/README.md"
+cat <<EOT > "${name}port/README.md"
 ${name}
 
 ${description}
 EOT
 printInfo "${name}port/README.md created"
 
-cat <<EOT >> "${name}port/cicd.groovy"
+touch "${name}port/cicd.groovy" && chtag -tc 819 "${name}port/cicd.groovy"
+cat <<EOT > "${name}port/cicd.groovy"
 node('linux')
 {
   stage('Build') {


### PR DESCRIPTION
* Adds an initial contributing.md file for both utils and a template for projects. Currently they are both the same.
* Also /bin/sh does not respect existing file tags when the append operator `>>` is used, so files end up being created in ebcdic 1047. Use `>` instead.