### PR TITLE
Print check results output when it contains errors

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -746,25 +746,33 @@ check()
     runInBackgroundWithTimeoutAndLog "${ZOPEN_CHECK_CMD} > $TMP_FIFO_PIPE 2>&1" "${ZOPEN_CHECK_TIMEOUT}"
     if command -V "${ZOPEN_CHECK_RESULTS}" >/dev/null 2>&1; then
       testStatus="$(${ZOPEN_CHECK_RESULTS} "${ZOPEN_ROOT}/${dir}" "${LOG_PFX}")"
-      printVerbose "Test status: $testStatus"
+      printVerbose "Test status:\n$testStatus"
+      testStatusError=false
       if echo "$testStatus" | grep -q -E "actualFailures:[ ]*[0-9]+"; then
         failures=$(echo "$testStatus" | grep "actualFailures:" | sed -e "s/.*actualFailures://" | tr -d ' ')
       else
-        printError "${ZOPEN_CHECK_RESULTS} needs to emit an actualFailures:<number> line"
+        printSoftError "${ZOPEN_CHECK_RESULTS} needs to emit an actualFailures:<number> line"
+        testStatusError=true
       fi
       if echo "$testStatus" | grep -q -E "expectedFailures:[ ]*[0-9]+"; then
         expected=$(echo "$testStatus" | grep "expectedFailures:" | sed -e "s/.*expectedFailures://" | tr -d ' ')
       else
-        printError "${ZOPEN_CHECK_RESULTS} needs to emit an expectedFailures:<number> line"
+        printSoftError "${ZOPEN_CHECK_RESULTS} needs to emit an expectedFailures:<number> line"
+      	testStatusError=true
       fi
       if echo "$testStatus" | grep -q -E "totalTests:[ ]*[0-9]+"; then
         totalTests=$(echo "$testStatus" | grep "totalTests:" | sed -e "s/.*totalTests://" | tr -d ' ')
+        if [ $totalTests -eq 0 ]; then
+          printSoftError "Total tests is 0"
+          testStatusError=true
+        fi
       else
-        printError "${ZOPEN_CHECK_RESULTS} needs to emit an totalTests:<number> line"
+        printSoftError "${ZOPEN_CHECK_RESULTS} needs to emit an totalTests:<number> line"
+      	testStatusError=true
       fi
-      if [ $totalTests -eq 0 ]; then
-        printError "Total tests is 0"
-      fi
+      if ${testStatusError}; then
+        printError "Test Status:\n$testStatus"
+      fi 
       success="$((totalTests-failures))"
       percent="$(echo "$success" "$totalTests" | awk '{printf "%.0f", $1 * 100 / $2}')"
       percenthundreth="$(echo "$success" "$totalTests" | awk '{printf "%.2f", $1 * 100 / $2}')"


### PR DESCRIPTION
If the zopen_check_results function returns invalid output, the error doesn't print the actual output so it is difficult to work out exactly what was wrong. 
It gets printed if the build is run with the verbose flag, but that needs a re-run.
It would save some time if we print it when we find it is invalid.
I've also made it run all the validation checks before exiting so that the user gets told of all the things that are wrong.