### PR TITLE
patch dir that exists but has no patches causes invalid file tagging

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -634,6 +634,10 @@ applyPatches()
   fi
 
   patches=$( (cd "${patch_dir}" && find . -name "*.patch" | sort))
+  if [ "${patches}x" = "x" ]; then
+    printWarning "No patches in ${patch_dir} to apply"
+    return 0
+  fi
   results=$( (cd "${code_dir}" && git status --porcelain --untracked-files=no 2>&1))
   failedcount=0
   if [ "${results}" != '' ]; then


### PR DESCRIPTION
The scenario I hit:

new port called grepport has a patches directory with just a LICENSE in it
first build works fine
next build, the code goes in to apply patches and ends up tagging new files (the generated Makefiles) which are unfortunately 1047 (but in automake where Makefile's are generated as 1047) to get tagged as ISO8859-1
Fix is to see there are no patch files
Had there been patch files, they would have already been applied, and we would have exited with that test.