### PR TITLE
Only use regex for files with spaces in the name

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -487,7 +487,7 @@ tagBinaryFiles()
 tagUntaggedFilesAsISO8859_1()
 {
   absdir="$1"
-  (cd "${absdir}" && find . ! -type d ! -type l | xargs -I {} chtag -qp {} | awk '{ if ($1 == "-") { if (NF == 4) { print $4 } else { sub(/^[ ]*([^ ]+ +){3}/, ""); print $0; }}}' | xargs -I {} chtag -tcISO8859-1 {})
+  (cd "${absdir}" && chtag -qpR . | awk '{ if ($1 == "-") { if (NF == 4) { print $4 } else { sub(/^[ ]*([^ ]+ +){3}/, ""); print $0; }}}' | xargs -I {} chtag -tcISO8859-1 {})
 }
 #
 # 'Quick' way to find untagged non-binary files. If the list of extensions grows, something more

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -487,7 +487,7 @@ tagBinaryFiles()
 tagUntaggedFilesAsISO8859_1()
 {
   absdir="$1"
-  (cd "${absdir}" && find . ! -type d ! -type l | xargs -I {} chtag -qp {} | awk '{ if ($1 == "-") { sub(/^[ ]*([^ ]+ +){3}/, ""); print $0; }}' | xargs -I {} chtag -tcISO8859-1 {})
+  (cd "${absdir}" && find . ! -type d ! -type l | xargs -I {} chtag -qp {} | awk '{ if ($1 == "-") { if (NF == 4) { print $4 } else { sub(/^[ ]*([^ ]+ +){3}/, ""); print $0; }}}' | xargs -I {} chtag -tcISO8859-1 {})
 }
 #
 # 'Quick' way to find untagged non-binary files. If the list of extensions grows, something more


### PR DESCRIPTION
From the comments in https://github.com/ZOSOpenTools/utils/commit/28f4dee93f0e1156f54e168e56a2537a66015227#commitcomment-87668713%3E the regex substitution introduced by that change causes performance problems on some ports (presumably based on the number of files that need tagging).
This change uses the old (simpler) mechanism for files without a space, and just resorts to the regex method when the filename does have a space.
I did try some alternatives using substrings and indexes, but I wasn't convinced that they would handle all cases. 