### PR TITLE
Update zopen-importenvs to depend on bash temporarily + fix zopen-build for tarballs (use gitignore)

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -545,10 +545,17 @@ extractTarBall()
       printError "Unable to initialize empty git repository for tarball"
     fi
   else
-    find . ! -name "*.pdf" ! -name "*.png" ! -name "*.bat" ! -name "*.jpg" ! -name "*.gif" ! -name "*.ttf" ! -name "*.wbmp" ! -type d ! -type l | xargs -I {} git add -f "{}"
-
     if ! git init . >/dev/null; then
       printError "Unable to initialize git repository for tarball"
+    fi
+
+    echo '\n*.jpg\n*.jpeg\n*.png\n*.gif\n*.bat\n*.pdf\n*.ttf\n*.wbmp' >> .gitignore
+    if ! iconv -f IBM-1047 -tISO8859-1 <.gitignore >.gitignoreascii || ! chtag -tcISO8859-1 .gitignoreascii || ! mv .gitignoreascii .gitignore; then
+      printError "Unable to make .gitignore ascii for tarball"
+    fi
+
+    if ! git add -f . >/dev/null; then
+      printError "Unable to add files for git repository"
     fi
 
     if ! git commit --allow-empty -m "Create Repository for patch management" >/dev/null; then

--- a/bin/zopen-importenvs
+++ b/bin/zopen-importenvs
@@ -4,11 +4,18 @@
 
 (return 0 2>/dev/null) && sourced=1 
 # What exit code did that give?
-if [[ $sourced -ne 1 ]]
+if [[ $sourced -ne 1 ]] || [[ "$2" -eq "-h" ]]
 then
-    echo "This script is not sourced."
+    echo "zopen-importenvs must be sourced via the . (dot) shell builtin"
     echo "USAGE: . ./zopen-importenvs [path to buildenv to fetch dependency]"
-    exit 1     
+    echo "If no argument is specified, zopen-importenvs will source all .env files from $HOME/zopen/prod and $HOME/zopen/boot"
+    echo "If an argument is specified and it represents a buildenv file, zopen-importenvs will source the ZOPEN_*_DEPS specified dependencies from $HOME/zopen/prod and $HOME/zopen/boot"
+    if [[ $sourced -ne 1 ]]; then
+      exit 1     
+    fi
+    if [[ "$2" -eq "-h" ]]; then
+      return 1     
+    fi
 fi
 
 #depsPath has the details of the location of ports whose env files are consumed for sourcing 
@@ -53,8 +60,8 @@ else
     #If path is provided then builedenv file is fetched from the provided path 
     pathForBuild=$1
     if [ ! -d "${HOME}/zopen/boot/" ] && [ ! -d "${HOME}/zopen/prod/" ]; then
-       echo "${HOME}/zopen/boot & ${HOME}/zopen/prod directories do not exist.  Exiting"
-       exit 1 
+       echo "${HOME}/zopen/boot & ${HOME}/zopen/prod directories do not exist. Exiting"
+       return 1 
     fi
 
     if [ -f ${pathForBuild}/buildenv ]

--- a/bin/zopen-importenvs
+++ b/bin/zopen-importenvs
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/env bash
 # Used for development to source all the boot/prod .envs
 
 


### PR DESCRIPTION
* `declare -a arrOfDirs` is only allowed in bash. We should try to implement a POSIX shell workaround for this part of the code
* Looks like the issue only occurs when it's called via `zopen-importenvs`
```
zopen-importenvs
/home/itodoro/projects/utils/bin/zopen-importenvs 44: FSUM7332 syntax error: got (, expecting fi
```
* Also add a -h option for help + add more details in help output
* For tarballs, use a .gitignore to ignore binaries rather than the existing logic which is to find the NOT of binaries and add them
FYI: @HarithaIBM