### PR TITLE
Modified configure check logic in zopen-build

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -953,7 +953,7 @@ resolveCommands()
     unset ZOPEN_BOOTSTRAP_CMD
   fi
 
-  if [ "${ZOPEN_CONFIGURE}x" != "skipx" ] && [ ! -z "$(command -v ${ZOPEN_CONFIGURE})" ]; then
+  if [ "${ZOPEN_CONFIGURE}x" != "skipx" ]; then
     if [ "${ZOPEN_CONFIGURE_MINIMAL}x" = "x" ]; then
       export ZOPEN_CONFIGURE_CMD="\"${ZOPEN_CONFIGURE}\" ${ZOPEN_CONFIGURE_OPTS} CC=${CC} \"CPPFLAGS=${CPPFLAGS}\" \"CFLAGS=${CFLAGS}\" CXX=${CXX} \"CXXFLAGS=${CXXFLAGS}\" \"LDFLAGS=${LDFLAGS}\" \"LIBS=${LIBS}\""
       export ZOPEN_CONFIGURE_MINIMAL="no"


### PR DESCRIPTION
During the build of gitport with ZOPEN_TYPE as GIT, the bootstrap step went through and it created configure script successfully but configure step was skipping. 
On analysis it is found that the string check for ZOPEN_CONFIGURE is not required. Hence, removed it.

On removing it and building gitport freshly again, the Configure step and build step of gitport is successful 