### PR TITLE
Support for tags in zopen download, update only if newer releases are found + more

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -1143,6 +1143,11 @@ if ! resolveCommands; then
   exit 4
 fi
 
+if command -V "zopen_init" >/dev/null 2>&1; then
+  printVerbose "Running zopen_init"
+  zopen_init "${ZOPEN_INSTALL_DIR}"
+fi
+
 if ${startShell}; then
   exec /bin/sh
 fi

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -156,6 +156,7 @@ printSyntax()
   echo "  where <option> may be one or more of:" >&2
   echo "  -h: print this information" >&2
   echo "  -v: run in verbose mode" >&2
+  echo "  -u|--updatedeps: update all dependencies by running zopen download" >&2
   echo "  --buildtype: release|debug" >&2
   echo "  --oci: build and publish an OCI image to \$ZOPEN_IMAGE_REGISTRY" >&2
   echo "  -e <env file>: source <env file> instead of buildenv to establish build environment" >&2
@@ -174,6 +175,7 @@ processOptions()
   startShell=false
   buildEnvFile="./buildenv"
   depsPath="$HOME/zopen/prod|$HOME/zopen/boot|/usr/bin/zopen/"
+  forceUpdateDeps=false
   while [[ $# -gt 0 ]]; do
     case $1 in
       "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
@@ -182,6 +184,9 @@ processOptions()
         ;;
       "-v" | "--v" | "-verbose" | "--verbose")
         verbose=true
+        ;;
+      "-u" | "--updateDeps")
+        forceUpdateDeps=true
         ;;
       "-buildtype" | "--buildtype" | "-b")
         shift
@@ -214,22 +219,6 @@ processOptions()
         ;;
     esac
     shift
-  done
-}
-
-checkDeps()
-{
-  deps=$*
-  for dep in $deps; do
-    fail=true
-    for path in `echo ${depsPath} | tr '|' '\n'` ; do
-      if [ -r "$path/${dep}/.env" ]; then
-        fail=false
-      fi
-    done
-    if $fail; then
-      printError "Unable to find .env for dependency ${dep}"
-    fi
   done
 }
 
@@ -304,10 +293,6 @@ checkEnv()
     deps="${ZOPEN_GIT_DEPS}"
   fi
 
-  if ! checkDeps "${deps}"; then
-    printError "One or more dependent products aren't available"
-  fi
-
   export ZOPEN_CA="${utilparentdir}/cacert.pem"
   if ! [ -r "${ZOPEN_CA}" ]; then
     printError "Internal Error. Certificate ${ZOPEN_CA} is required"
@@ -336,13 +321,32 @@ setDepsEnv()
 
   orig="${PWD}"
   for dep in $deps; do
-    for path in `echo ${depsPath} | tr '|' '\n'` ; do
-      if [ -r "$path/${dep}/.env" ]; then
-        depdir="$path/${dep}"
-        printVerbose "Setting up ${depdir} dependency environment"
-        cd "${depdir}" && . ./.env
+    foundDep=false
+    if ! $forceUpdateDeps; then
+      for path in `echo ${depsPath} | tr '|' '\n'` ; do
+        if [ -r "$path/${dep}/.env" ]; then
+          depdir="$path/${dep}"
+          printVerbose "Setting up ${depdir} dependency environment"
+          cd "${depdir}" && . ./.env
+          foundDep=true
+          break
+        fi
+      done
+    fi
+    if ! $foundDep; then
+      if ! $forceUpdateDeps; then
+        printWarning "Dependency $dep not found. Downloading via zopen-download"
+      else
+        printHeader "Updating dependency $dep. Downloading via zopen-download"
       fi
-    done
+      path=$(echo ${depsPath} | tr '|' '\n' | head -1)
+      printVerbose "Running zopen download -r $dep -d $path"
+      if ! zopen download -r $dep -d $path; then
+        printError "zopen download command failed"
+      fi
+      printVerbose "Setting up ${path}/${dep} dependency environment"
+      cd "${path}/${dep}" && . ./.env
+    fi
   done
   cd "${orig}" || exit 99
 }

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -815,6 +815,10 @@ build()
 
 check()
 {
+  if command -V "zopen_pre_check" >/dev/null 2>&1; then
+    printVerbose "Running zopen_pre_check"
+    zopen_pre_check "${ZOPEN_INSTALL_DIR}"
+  fi
   checklog="${LOG_PFX}_check.log"
   results=$ZOPEN_TEST_STATUS_SKIPPED # skipped
   if [ -n "${ZOPEN_CHECK_CMD}" ]; then

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -398,6 +398,7 @@ setEnv()
 
   export SSL_CERT_FILE="${ZOPEN_CA}"
   export GIT_SSL_CAINFO="${ZOPEN_CA}"
+  export CURL_CA_BUNDLE="${ZOPEN_CA}"
 
   setDepsEnv
 
@@ -606,7 +607,7 @@ downloadTarBall()
     echo "Using existing tarball directory ${dir}" >&2
   else
     if ${verbose}; then
-      printVerbose "curl -k -L -o ${tarballz} ${ZOPEN_TARBALL_URL}"
+      printVerbose "curl -L -o ${tarballz} ${ZOPEN_TARBALL_URL}"
     fi
     #
     # Some older tarballs (openssl) contain a pax_global_header file. Remove it
@@ -619,9 +620,9 @@ downloadTarBall()
     # Make a first call to just get the headers and toss everything out just to
     # set up the cache (requirec for openssl)
     #
-    curl -I -k "${ZOPEN_TARBALL_URL}" >/dev/null 2>&1
+    curl -I "${ZOPEN_TARBALL_URL}" >/dev/null 2>&1
 
-    if ! curl -k -L -0 -o "${tarballz}" "${ZOPEN_TARBALL_URL}" 2>/dev/null; then
+    if ! curl -L -0 -o "${tarballz}" "${ZOPEN_TARBALL_URL}";  then
       if [ -f "${tarballz}" ] && [ $(wc -c "${tarballz}" | awk '{print $1}') -lt 1024 ]; then
         cat "${tarballz}" >/dev/null
       else

--- a/bin/lib/zopen-download
+++ b/bin/lib/zopen-download
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Downloads and extracts the latest ZOSOpenTools releases from GitHub
+# Package Manager for z/OS Open Tools - https://github.com/ZOSOpenTools
 
 export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
 
@@ -8,51 +8,16 @@ export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
 printSyntax() 
 {
   args=$*
-  echo "zopen-download is a tool that downloads and extracts the latest z/OS Open Tools releases from GitHub Releases." >&2
+  echo "zopen-download is a package manager for z/OS Open Tools. The default action is to download all packages." >&2
   echo "If you have a Github OAUTH token, export the environment variable ZOPEN_GIT_OAUTH_TOKEN" >&2
   echo "Syntax: zopen-download [<option>]*" >&2
   echo "  where <option> may be one or more of:" >&2
   echo "  --list: list all available z/OS Open Tools"  >&2
-#TODO: future option
-#  echo "  --filter <color>: filter based on quality (green - all tests passing, blue - most tests passing, yellow - some tests passing, red - no tests passing, none (default))"  >&2
+  echo "  --update: update all available z/OS Open Tools packages"  >&2
+  echo "  --filter <color>: filter based on quality (green - all tests passing, blue - most tests passing, yellow - some tests passing, red - no tests passing, none (default))"  >&2
   echo "  -d <dir>: directory to download binaries to.  Uses current working directory if not specified." >&2
   echo "  -r <repo>: specific repo name to download. Downloads all ZOSOpenTools if not specified." >&2
 }
-
-args=$*
-download=$PWD
-filter=none
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    "-d")
-      download=$2;
-      shift
-      ;;
-    "-r")
-      toolrepo=$2;
-      shift
-      ;;
-    "--list")
-      list=1;
-      ;;
-    "--filter")
-      filter=$2;
-      ;;
-    "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
-      printSyntax "${args}"
-      exit 4
-      ;;
-    *)
-      printError "Unknown option ${1} specified"
-      ;;
-  esac
-  shift;
-done
-
-if [ ! -z "${ZOPEN_GIT_OAUTH_TOKEN}" ]; then
-  OAUTH_TOKEN_OPTION='-H'
-  OAUTH_TOKEN="Authorization: Bearer ${ZOPEN_GIT_OAUTH_TOKEN}" 
-fi
 
 getContentsFromGithub()
 {
@@ -67,35 +32,15 @@ getContentsFromGithub()
   echo "$repo_results";
 }
 
-if ! repo_results="$(getContentsFromGithub "https://api.github.com/users/ZOSOpenTools/repos?per_page=100")"; then
-  exit 4;
-fi
-repo_results=$(echo "$repo_results" | grep "\"full_name\":" | cut -d '"' -f 4)
-
-if [ ! -z "$list" ]; then
-  printf "${NC}${UNDERLINE}${1}%-25s %-25s %-25s\n${NC}" "Repo" "Build Status" "Quality Report"
-fi
-
-if [ ! -d "${download}" ]; then
-  mkdir -p "${download}"
-fi
-
-if [ ! -z "${download}" -a -d "${download}" ]; then
-  cd "${download}"
-fi
-
-foundPort=false
-for repo in $(echo ${repo_results}); do
-  repo=${repo#"ZOSOpenTools/"}
-  if [ -z $toolrepo ] || [ "${toolrepo}" = "${repo}" ]; then
-    name=${repo%port}
-    if [ "${repo}" = "${name}" ]; then
-      continue;
-    fi
-    if [ ! -z "$list" ]; then
+printListEntries()
+{
+  printf "${NC}${UNDERLINE}${1}%-20s %-20s %-20s %-10s %-25s\n${NC}" "Repo" "Your version" "Latest Tag" "Status" "Quality"
+  echo "$repoArray" | xargs| tr ' ' '\n' | sort | while read repo; do
+      name=${repo%port}
       if ! contents="$(getContentsFromGithub "https://api.github.com/repos/ZOSOpenTools/${repo}/releases/latest")"; then
         exit 4;
       fi
+      latestTag="$(echo "$contents" | grep "\"tag_name\":" | cut -d '"' -f 4)"
       statusline="$(echo "$contents" | grep "\"body\":.*Test Status:.*(.*)<br />")"
       buildQuality="$(echo "$statusline" | sed -e "s#.*Test Status:<\/b>##" -e "s#[ ]*(.*##" | tr -d ' ')"
       testStatus="$(echo "$statusline" | sed -e "s#.*Test Status:<\/b>[^(]*(##" -e "s#).*##")"
@@ -103,21 +48,47 @@ for repo in $(echo ${repo_results}); do
         buildQuality="Untested"
         testStatus="N/A";
       fi
-      printf '%-25s %-25s %-25s\n' "$repo" "$buildQuality" "$testStatus"
+
+	if [ -e "${name}/.releaseinfo" ]; then
+	  originalTag=$(cat "${name}/.releaseinfo" | xargs) 
+        else
+	  originalTag="Not installed"
+	fi
+	if [ "${latestTag}" = "${originalTag}" ]; then
+	  printInfo "${repo} with tag ${latestTag} already present. Skipping..."
+	  continue;
+	fi
+      printf '%-20s %-20s %-20s %-10s %-25s\n' "$repo" "$originalTag" "$latestTag" "$buildQuality" "$testStatus"
       continue;
-    fi
-    foundPort=true
-    printHeader "Downloading latest release from $repo"
+  done
+}
+
+downloadRepos()
+{
+  printHeader "Checking ZOSOpenTools repos..."
+  echo "$repoArray" | xargs | tr ' ' '\n' | sort | while read repo; do
+    name=${repo%port}
+    printHeader "Checking $repo"
     if ! latest_url="$(getContentsFromGithub "https://api.github.com/repos/ZOSOpenTools/${repo}/releases/latest")"; then
       exit 4;
     fi
-    latest_url="$(echo "$latest_url" | grep browser_download_url | cut -d '"' -f 4)"
-
-    if [ -z $latest_url ]; then
-      printWarning "No releases published for $repo"
+    if [ -z "$latest_url" ]; then
+      printInfo "No releases published for $repo"
       continue
     fi
 
+    latestTag="$(echo "$latest_url" | grep "\"tag_name\":" | cut -d '"' -f 4)"
+    if $updateOnly; then
+	if [ -e "${name}/.releaseinfo" ]; then
+	  originalTag=$(cat "${name}/.releaseinfo" | xargs) 
+	fi
+	if [ "${latestTag}" = "${originalTag}" ]; then
+      	  printInfo "${repo} with tag ${latestTag} already present. Skipping..."
+	  continue;
+	fi
+    fi
+    latest_url="$(echo "$latest_url" | grep "\"browser_download_url\":" | cut -d '"' -f 4)"
+    printHeader "Downloading latest release from $repo"
     if ! curl -k -L ${latest_url} -O 2>/dev/null; then
       printError "Could not download ${latest_url}"
     fi
@@ -140,9 +111,91 @@ for repo in $(echo ${repo_results}); do
     if ! ln -s $dirname $name; then
       printError "Could not create symbolic link name"
     fi 
+done
+}
+
+
+# Main code start here
+args=$*
+downloadDir=$PWD
+filter=none
+updateOnly=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    "-d")
+      downloadDir=$2;
+      shift
+      ;;
+    "-r")
+      toolrepo=$2;
+      shift
+      ;;
+    "-u" | "--update" | "-update")
+      updateOnly=true
+      ;;
+    "--list")
+      list=1;
+      ;;
+    "-f" | "-filter" | "--filter")
+      filter=$2;
+      ;;
+    "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
+      printSyntax "${args}"
+      exit 4
+      ;;
+    *)
+      printError "Unknown option ${1} specified"
+      ;;
+  esac
+  shift;
+done
+
+if [ ! -z "${ZOPEN_GIT_OAUTH_TOKEN}" ]; then
+  OAUTH_TOKEN_OPTION='-H'
+  OAUTH_TOKEN="Authorization: Bearer ${ZOPEN_GIT_OAUTH_TOKEN}" 
+else
+  printWarning "Setting ZOPEN_GIT_OAUTH_TOKEN is recommended to ensure that you do not hit the GitHub API cap"
+fi
+
+# Retrieve all repositories
+if ! repo_results="$(getContentsFromGithub "https://api.github.com/users/ZOSOpenTools/repos?per_page=100")"; then
+  exit 4;
+fi
+repo_results=$(echo "$repo_results" | grep "\"full_name\":" | cut -d '"' -f 4)
+
+if [ ! -d "${downloadDir}" ]; then
+  mkdir -p "${downloadDir}"
+  if $?; then
+    printError "Could not create download directory: $downloadDir"
+  fi
+fi
+
+if [ ! -z "${download}" -a -d "${download}" ]; then
+  cd "${download}"
+fi
+
+# Parse repositories for zopen framework repos
+foundPort=false
+repoArray=""
+for repo in $(echo ${repo_results}); do
+  repo=${repo#"ZOSOpenTools/"}
+  name=${repo%port}
+  if [ -z $toolrepo ] || [ "${toolrepo}" = "${repo}" ] || [ "${toolrepo}" = "${name}" ]; then
+    # Skip if the repo does not end with port
+    if [ "${repo}" = "${name}" ]; then
+      continue;
+    fi
+    repoArray="$repoArray $repo"
   fi
 done
 
-if ! $foundPort && test -z $list; then
-  printError "Could not find $toolrepo. Run with --list option to view the available ports"
+if [ -z "$repoArray" ]; then
+  printError "Could not find specified $toolrepo. Run with --list option to view the available ports"
 fi
+
+if [ ! -z "$list" ]; then
+  printListEntries
+  exit 0;
+fi
+
+downloadRepos

--- a/bin/lib/zopen-download
+++ b/bin/lib/zopen-download
@@ -23,7 +23,7 @@ printSyntax()
 getContentsFromGithub()
 {
   url=$1
-  if ! repo_results=$(curl $OAUTH_TOKEN_OPTION "$OAUTH_TOKEN" -k -s "$url"); then
+  if ! repo_results=$(curl $OAUTH_TOKEN_OPTION "$OAUTH_TOKEN" -s "$url"); then
     printError "curl command could not download $url"
   fi
   
@@ -86,7 +86,7 @@ downloadRepos()
     fi
     latest_url="$(echo "$latest_url" | grep "\"browser_download_url\":" | cut -d '"' -f 4)"
     printHeader "Downloading latest release from $repo"
-    if ! curl -k -L ${latest_url} -O 2>/dev/null; then
+    if ! curl -L ${latest_url} -O 2>/dev/null; then
       printError "Could not download ${latest_url}"
     fi
 
@@ -142,23 +142,32 @@ while [[ $# -gt 0 ]]; do
       ;;
     "-f" | "-filter" | "--filter")
       filter=$2;
+      shift
       ;;
     "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
       printSyntax "${args}"
       exit 4
       ;;
     *)
-      printError "Unknown option ${1} specified"
+      chosenRepos=$1;
       ;;
   esac
   shift;
 done
 
+export ZOPEN_CA="${utildir}/../../cacert.pem"
+if ! [ -r "${ZOPEN_CA}" ]; then
+  printError "Internal Error. Certificate ${ZOPEN_CA} is required"
+fi
+export SSL_CERT_FILE="${ZOPEN_CA}"
+export GIT_SSL_CAINFO="${ZOPEN_CA}"
+export CURL_CA_BUNDLE="${ZOPEN_CA}"
+
 if [ ! -z "${ZOPEN_GIT_OAUTH_TOKEN}" ]; then
   OAUTH_TOKEN_OPTION='-H'
   OAUTH_TOKEN="Authorization: Bearer ${ZOPEN_GIT_OAUTH_TOKEN}" 
 else
-  printWarning "Setting ZOPEN_GIT_OAUTH_TOKEN is recommended to ensure that you do not hit the GitHub API cap"
+  printWarning "Setting ZOPEN_GIT_OAUTH_TOKEN is recommended to ensure that you do not hit the GitHub API cap. See --help for more details."
 fi
 
 # Retrieve all repositories

--- a/bin/lib/zopen-download
+++ b/bin/lib/zopen-download
@@ -16,8 +16,9 @@ printSyntax()
   echo "  --update: update z/OS Open Tools packages. On by default."  >&2
   echo "  --force: force downloads all z/OS Open Tools packages."  >&2
   echo "  <coming soon> --filter <color>: filter based on quality (green - all tests passing, blue - most tests passing, yellow - some tests passing, red - no tests passing, none (default))"  >&2
+  echo "  -v: run in verbose mode" >&2
   echo "  -d <dir>: directory to download binaries to.  Uses current working directory if not specified." >&2
-  echo "  -r <repo,...>: a set of comman delimited projects to download. Downloads all ZOSOpenTools if not specified." >&2
+  echo "  -r <repo,...>: a set of comma delimited projects to download. Downloads all ZOSOpenTools if not specified." >&2
 }
 
 getContentsFromGithub()
@@ -62,10 +63,9 @@ printListEntries()
 
 downloadRepos()
 {
-  printHeader "Checking ZOSOpenTools repos..."
   echo "$repoArray" | xargs | tr ' ' '\n' | sort | while read repo; do
     name=${repo%port}
-    printHeader "Checking $repo"
+    printHeader "Preparing to download $repo"
     if ! latest_url="$(getContentsFromGithub "https://api.github.com/repos/ZOSOpenTools/${repo}/releases/latest")"; then
       exit 4;
     fi
@@ -80,13 +80,16 @@ downloadRepos()
         originalTag=$(cat "${name}/.releaseinfo" | xargs) 
       fi
       if [ "${latestTag}" = "${originalTag}" ]; then
-        printInfo "${repo} with tag ${latestTag} already present. Skipping..."
+        printInfo "${downloadDir}/${name} with tag ${latestTag} already installed. Skipping..."
         continue;
       fi
     fi
     latest_url="$(echo "$latest_url" | grep "\"browser_download_url\":" | cut -d '"' -f 4)"
-    printHeader "Downloading latest release from $repo"
-    if ! curl -L ${latest_url} -O 2>/dev/null; then
+    printInfo "Downloading latest release from $repo..."
+    if ! $verbose; then
+      redirectToDevNull="2>/dev/null"
+    fi 
+    if ! runAndLog "curl -L ${latest_url} -O ${redirectToDevNull}"; then
       printError "Could not download ${latest_url}"
     fi
 
@@ -95,8 +98,8 @@ downloadRepos()
       printError "${pax} was not actually downloaded?"
     fi
 
-    printHeader "Extracting $pax"
-    if ! pax -rf $pax -p p 2>/dev/null; then
+    printInfo "Extracting $pax..."
+    if ! runAndLog "pax -rf $pax -p p ${redirectToDevNull}"; then
       printWarning "Could not extract $pax. Skipping"
       continue;
     fi
@@ -107,12 +110,14 @@ downloadRepos()
     if [ -L $name ]; then
       rm $name
     fi 
+
     if ! ln -s $dirname $name; then
       printError "Could not create symbolic link name"
     fi 
 
     # Add tag information as a .releaseinfo file
     echo "$latestTag" > "${name}/.releaseinfo"
+    printInfo "Successfully downloaded $name to $downloadDir/$name/"
 done
 }
 
@@ -121,6 +126,7 @@ done
 args=$*
 downloadDir=$PWD
 updateOnly=true
+verbose=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     "-d")
@@ -134,19 +140,22 @@ while [[ $# -gt 0 ]]; do
     "-u" | "--update" | "-update")
       updateOnly=true
       ;;
-    "-force" | "--force")
+    "-f" | "-force" | "--force")
       updateOnly=false
       ;;
     "--list")
       list=1;
       ;;
-    "-f" | "-filter" | "--filter")
+    "-filter" | "--filter")
       filter=$2;
       shift
       ;;
     "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
       printSyntax "${args}"
       exit 4
+      ;;
+    "-v" | "--v" | "-verbose" | "--verbose")
+       verbose=true
       ;;
     *)
       chosenRepos=$1;
@@ -197,7 +206,7 @@ for repo in $(echo ${repo_results}); do
   if [ -z "${chosenRepos}" ]; then
     repoArray="$repoArray $repo"
   else
-    for toolrepo in $(echo ${chosenRepos} | tr ',' '\n'); do
+    for toolrepo in $(echo "${chosenRepos}" | tr ',' '\n'); do
       if [ "${toolrepo}" = "${repo}" ] || [ "${toolrepo}" = "${name}" ]; then
         # Skip if the repo does not end with port
         if [ "${repo}" = "${name}" ]; then

--- a/bin/lib/zopen-download
+++ b/bin/lib/zopen-download
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Package Manager for z/OS Open Tools - https://github.com/ZOSOpenTools
+# Download utility for z/OS Open Tools - https://github.com/ZOSOpenTools
 
 export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
 
@@ -8,7 +8,7 @@ export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
 printSyntax() 
 {
   args=$*
-  echo "zopen-download is a package manager for z/OS Open Tools. The default action is to download/update all packages." >&2
+  echo "zopen-download is a download utility for z/OS Open Tools. The default action is to download/update all packages." >&2
   echo "If you have a Github OAUTH token, export the environment variable ZOPEN_GIT_OAUTH_TOKEN" >&2
   echo "Syntax: zopen-download [<option>]*" >&2
   echo "  where <option> may be one or more of:" >&2

--- a/bin/lib/zopen-download
+++ b/bin/lib/zopen-download
@@ -8,15 +8,16 @@ export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
 printSyntax() 
 {
   args=$*
-  echo "zopen-download is a package manager for z/OS Open Tools. The default action is to download all packages." >&2
+  echo "zopen-download is a package manager for z/OS Open Tools. The default action is to download/update all packages." >&2
   echo "If you have a Github OAUTH token, export the environment variable ZOPEN_GIT_OAUTH_TOKEN" >&2
   echo "Syntax: zopen-download [<option>]*" >&2
   echo "  where <option> may be one or more of:" >&2
   echo "  --list: list all available z/OS Open Tools"  >&2
-  echo "  --update: update all available z/OS Open Tools packages"  >&2
-  echo "  --filter <color>: filter based on quality (green - all tests passing, blue - most tests passing, yellow - some tests passing, red - no tests passing, none (default))"  >&2
+  echo "  --update: update z/OS Open Tools packages. On by default."  >&2
+  echo "  --force: force downloads all z/OS Open Tools packages."  >&2
+  echo "  <coming soon> --filter <color>: filter based on quality (green - all tests passing, blue - most tests passing, yellow - some tests passing, red - no tests passing, none (default))"  >&2
   echo "  -d <dir>: directory to download binaries to.  Uses current working directory if not specified." >&2
-  echo "  -r <repo>: specific repo name to download. Downloads all ZOSOpenTools if not specified." >&2
+  echo "  -r <repo,...>: a set of comman delimited projects to download. Downloads all ZOSOpenTools if not specified." >&2
 }
 
 getContentsFromGithub()
@@ -35,31 +36,27 @@ getContentsFromGithub()
 printListEntries()
 {
   printf "${NC}${UNDERLINE}${1}%-20s %-20s %-20s %-10s %-25s\n${NC}" "Repo" "Your version" "Latest Tag" "Status" "Quality"
-  echo "$repoArray" | xargs| tr ' ' '\n' | sort | while read repo; do
-      name=${repo%port}
-      if ! contents="$(getContentsFromGithub "https://api.github.com/repos/ZOSOpenTools/${repo}/releases/latest")"; then
-        exit 4;
-      fi
-      latestTag="$(echo "$contents" | grep "\"tag_name\":" | cut -d '"' -f 4)"
-      statusline="$(echo "$contents" | grep "\"body\":.*Test Status:.*(.*)<br />")"
-      buildQuality="$(echo "$statusline" | sed -e "s#.*Test Status:<\/b>##" -e "s#[ ]*(.*##" | tr -d ' ')"
-      testStatus="$(echo "$statusline" | sed -e "s#.*Test Status:<\/b>[^(]*(##" -e "s#).*##")"
-      if [ -z "$buildQuality" ]; then
-        buildQuality="Untested"
-        testStatus="N/A";
-      fi
+  echo "$repoArray" | xargs | tr ' ' '\n' | sort | while read repo; do
+    name=${repo%port}
+    if ! contents="$(getContentsFromGithub "https://api.github.com/repos/ZOSOpenTools/${repo}/releases/latest")"; then
+      exit 4;
+    fi
+    latestTag="$(echo "$contents" | grep "\"tag_name\":" | cut -d '"' -f 4)"
+    statusline="$(echo "$contents" | grep "\"body\":.*Test Status:.*(.*)<br />")"
+    buildQuality="$(echo "$statusline" | sed -e "s#.*Test Status:<\/b>##" -e "s#[ ]*(.*##" | tr -d ' ')"
+    testStatus="$(echo "$statusline" | sed -e "s#.*Test Status:<\/b>[^(]*(##" -e "s#).*##")"
+    if [ -z "$buildQuality" ]; then
+      buildQuality="Untested"
+      testStatus="N/A";
+    fi
 
-	if [ -e "${name}/.releaseinfo" ]; then
-	  originalTag=$(cat "${name}/.releaseinfo" | xargs) 
-        else
-	  originalTag="Not installed"
-	fi
-	if [ "${latestTag}" = "${originalTag}" ]; then
-	  printInfo "${repo} with tag ${latestTag} already present. Skipping..."
-	  continue;
-	fi
-      printf '%-20s %-20s %-20s %-10s %-25s\n' "$repo" "$originalTag" "$latestTag" "$buildQuality" "$testStatus"
-      continue;
+    if [ -e "${name}/.releaseinfo" ]; then
+      originalTag=$(cat "${name}/.releaseinfo" | xargs) 
+    else
+      originalTag="Not installed"
+    fi
+    printf '%-20s %-20s %-20s %-10s %-25s\n' "$repo" "$originalTag" "$latestTag" "$buildQuality" "$testStatus"
+    continue;
   done
 }
 
@@ -79,13 +76,13 @@ downloadRepos()
 
     latestTag="$(echo "$latest_url" | grep "\"tag_name\":" | cut -d '"' -f 4)"
     if $updateOnly; then
-	if [ -e "${name}/.releaseinfo" ]; then
-	  originalTag=$(cat "${name}/.releaseinfo" | xargs) 
-	fi
-	if [ "${latestTag}" = "${originalTag}" ]; then
-      	  printInfo "${repo} with tag ${latestTag} already present. Skipping..."
-	  continue;
-	fi
+      if [ -e "${name}/.releaseinfo" ]; then
+        originalTag=$(cat "${name}/.releaseinfo" | xargs) 
+      fi
+      if [ "${latestTag}" = "${originalTag}" ]; then
+        printInfo "${repo} with tag ${latestTag} already present. Skipping..."
+        continue;
+      fi
     fi
     latest_url="$(echo "$latest_url" | grep "\"browser_download_url\":" | cut -d '"' -f 4)"
     printHeader "Downloading latest release from $repo"
@@ -105,12 +102,17 @@ downloadRepos()
     fi
     rm -f "${pax}"
     dirname=${pax%.pax.Z}
+
+    # Remove old symlink and recreate
     if [ -L $name ]; then
       rm $name
     fi 
     if ! ln -s $dirname $name; then
       printError "Could not create symbolic link name"
     fi 
+
+    # Add tag information as a .releaseinfo file
+    echo "$latestTag" > "${name}/.releaseinfo"
 done
 }
 
@@ -118,8 +120,7 @@ done
 # Main code start here
 args=$*
 downloadDir=$PWD
-filter=none
-updateOnly=false
+updateOnly=true
 while [[ $# -gt 0 ]]; do
   case "$1" in
     "-d")
@@ -127,11 +128,14 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     "-r")
-      toolrepo=$2;
+      chosenRepos=$2;
       shift
       ;;
     "-u" | "--update" | "-update")
       updateOnly=true
+      ;;
+    "-force" | "--force")
+      updateOnly=false
       ;;
     "--list")
       list=1;
@@ -180,12 +184,19 @@ repoArray=""
 for repo in $(echo ${repo_results}); do
   repo=${repo#"ZOSOpenTools/"}
   name=${repo%port}
-  if [ -z $toolrepo ] || [ "${toolrepo}" = "${repo}" ] || [ "${toolrepo}" = "${name}" ]; then
-    # Skip if the repo does not end with port
-    if [ "${repo}" = "${name}" ]; then
-      continue;
-    fi
+
+  if [ -z "${chosenRepos}" ]; then
     repoArray="$repoArray $repo"
+  else
+    for toolrepo in $(echo ${chosenRepos} | tr ',' '\n'); do
+      if [ "${toolrepo}" = "${repo}" ] || [ "${toolrepo}" = "${name}" ]; then
+        # Skip if the repo does not end with port
+        if [ "${repo}" = "${name}" ]; then
+          continue;
+        fi
+        repoArray="$repoArray $repo"
+      fi
+    done
   fi
 done
 


### PR DESCRIPTION
New support for **zopen download**:
`zopen download -u` - will automatically update project(s) if a newer release of the project is found. This is the default action
* `zopen download -f` - will automatically download project(s).
* `zopen download -r makeport -u` - will update makeport only if a newer release of makeport is found
* Also adds support for specifying multiple projects via the -r option (comma delimited) or just like this `zopen download make,ncurses`
* Also adds support for specifying the project name as opposed to the repo name. So `zopen download -r make` will not work.
* Also adds support for `zopen download make` so that you don't have to specify -r.  

**zopen build enhancements**
* Change to default behaviour: If a dependency is not found, it will attempt to download it
* `zopen build -u` - Will automatically update all buildenv dependencies by calling zopen download

Also adds:
* `zopen_init` hook that runs before bootstrap/configure
* `zopen_pre_check` hook