### PR TITLE
fix: correctly test for help flag

### DIFF
--- a/bin/zopen-importenvs
+++ b/bin/zopen-importenvs
@@ -4,7 +4,7 @@
 
 (return 0 2>/dev/null) && sourced=1 
 # What exit code did that give?
-if [[ $sourced -ne 1 ]] || [[ "$2" -eq "-h" ]]
+if [[ $sourced -ne 1 ]] || [[ "$1" == "-h" ]]
 then
     echo "zopen-importenvs must be sourced via the . (dot) shell builtin"
     echo "USAGE: . ./zopen-importenvs [path to buildenv to fetch dependency]"
@@ -13,7 +13,7 @@ then
     if [[ $sourced -ne 1 ]]; then
       exit 1     
     fi
-    if [[ "$2" -eq "-h" ]]; then
+    if [[ "$1" == "-h" ]]; then
       return 1     
     fi
 fi


### PR DESCRIPTION
Fixes #98 

The -eq equality check is a numeric comparison and doesn't work properly for comparing strings. The style guide recommends using ==.
I've also changed it to check for "-h" as the first parameter, which is how I'd expect people to use it if they just want the help text. We'll need more sophisticated parsing of arguments if you want to test for it anywhere in the parameters.