### PR TITLE
Print zopen syntax when bad args are passed + fix issue where configlog was emitted on make error

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -823,9 +823,9 @@ build()
     create_fifo_pipe "${makelog}"
     if ! runAndLog "${ZOPEN_MAKE_CMD} > $TMP_FIFO_PIPE"; then
       if [ "${ZOPEN_MAKE_MINIMAL}" = "yes" ]; then
-        printError "Make (minimal) failed. Log: ${configlog}"
+        printError "Make (minimal) failed. Log: ${makelog}"
       else
-        printError "Make (full) failed. Log: ${configlog}"
+        printError "Make (full) failed. Log: ${makelog}"
       fi
     fi
   else
@@ -1056,7 +1056,7 @@ resolveCommands()
       export ZOPEN_MAKE_CMD="\"${ZOPEN_MAKE}\" ${ZOPEN_MAKE_OPTS} CC=${CC} \"CPPFLAGS=${CPPFLAGS}\" \"CFLAGS=${CFLAGS}\" CXX=${CXX} \"CXXFLAGS=${CXXFLAGS}\" \"LDFLAGS=${LDFLAGS}\""
       export ZOPEN_MAKE_MINIMAL="no"
     else
-      export ZOPEN_MAKE_CMD="\"${ZOPEN_MAKE}\" ${ZOPEN_MAKE_OPTS}"
+      export ZOPEN_MAKE_CMD="\"${ZOPEN_MAKE}\""
       export ZOPEN_MAKE_MINIMAL="yes"
     fi
   else

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -1056,7 +1056,7 @@ resolveCommands()
       export ZOPEN_MAKE_CMD="\"${ZOPEN_MAKE}\" ${ZOPEN_MAKE_OPTS} CC=${CC} \"CPPFLAGS=${CPPFLAGS}\" \"CFLAGS=${CFLAGS}\" CXX=${CXX} \"CXXFLAGS=${CXXFLAGS}\" \"LDFLAGS=${LDFLAGS}\""
       export ZOPEN_MAKE_MINIMAL="no"
     else
-      export ZOPEN_MAKE_CMD="\"${ZOPEN_MAKE}\""
+      export ZOPEN_MAKE_CMD="\"${ZOPEN_MAKE}\" ${ZOPEN_MAKE_OPTS}"
       export ZOPEN_MAKE_MINIMAL="yes"
     fi
   else

--- a/bin/zopen
+++ b/bin/zopen
@@ -2,11 +2,8 @@
 #
 # General purpose zopen script
 #
-
-printSyntax() 
+printSyntax()
 {
-  args=$*
-  echo "zopen is a general purpose script to be used with the ZOSOpenTools ports." >&2
   echo "" >&2
   echo "Syntax: zopen <command>" >&2
   echo "where <command> may be one of the following:" >&2
@@ -14,6 +11,13 @@ printSyntax()
   echo " download: downloads binaries" >&2
   echo " generate: generate a zopen project" >&2
   echo "" >&2
+}
+
+printHelp() 
+{
+  args=$*
+  echo "zopen is a general purpose script to be used with the ZOSOpenTools ports." >&2
+  printSyntax
   echo "Example usage:" >&2
   echo " # Build a port" >&2
   echo " zopen build -v # Build port" >&2
@@ -44,14 +48,16 @@ while [[ $# -gt 0 ]]; do
       exec "${bindir}/lib/zopen-generate" $@
       ;;
     "help" | "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
-      printSyntax "${args}"
-      exit 4
+      printHelp "${args}"
+      exit 0
       ;;
     *)
-      printError "Unknown option ${1} specified"
+      printSoftError "Unknown option ${1} specified"
+      printSyntax "${args}"
+      exit 8
       ;;
   esac
   shift;
 done
 
-printSyntax
+printHelp


### PR DESCRIPTION
* Addresses https://github.com/ZOSOpenTools/utils/issues/111