### PR TITLE
Use ZOPEN_IN_ZOPEN_BUILD envar to indicate that we're in zopen build (to be used in project .env files)

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -250,6 +250,9 @@ loadBuildEnv()
     printError "Build environment file '$buildEnvFile' does not exist or is not readable"
   fi
 
+  # Indicates to .env script that we're in zopen build
+  export ZOPEN_IN_ZOPEN_BUILD=1
+
   . $buildEnvFile
 }
 


### PR DESCRIPTION
Needed for ncurses, and zoslib so that the ZOPEN_* envars don't pollute the user environment