### PR TITLE
fix: allow cxx compiler to tolerate options after arguments

### DIFF
--- a/bin/lib/common.inc
+++ b/bin/lib/common.inc
@@ -32,6 +32,7 @@ defineEnvironment()
   export _TAG_REDIR_OUT=txt
 
   # Required for proper operation of xlclang
+  export _CC_CCMODE=1
   export _C89_CCMODE=1
   export _CXX_CCMODE=1
 

--- a/bin/lib/common.inc
+++ b/bin/lib/common.inc
@@ -33,6 +33,7 @@ defineEnvironment()
 
   # Required for proper operation of xlclang
   export _C89_CCMODE=1
+  export _CXX_CCMODE=1
 
   # Required for proper operation of (USS shipped) sed
   export _UNIX03=YES


### PR DESCRIPTION
Fixes #125 

Adding  _CXX_CCMODE into common.inc to match  _C89_CCMODE.

This is enough to fix the issue I was seeing with the cmake build, but I wonder whether we should have  _CC_CCMODE set as well to be consistent?

