### PR TITLE
Add symlink support + optionally generate pax.Z file

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -185,6 +185,8 @@ printSyntax()
   echo "  -c|--clean: Deletes all of the build output and forces reconfigure with next build"
   echo "  -f|--force-rebuild: forces a rebuild, including running bootstrap and configure again"
   echo "  -g|--get-source: get the source and apply patch without building"
+  echo "  -gp|--generate-pax: generate a pax.Z file based on the install contents"
+  echo "  -sym|--symlink: generate a symlink from the project name to \${ZOPEN_INSTALL_DIR}"
   echo "  -s: exec a shell before running configure.  Useful when manually building ports."
   opts=$(printEnvVar)
   echo "${opts}" )>&2
@@ -202,6 +204,8 @@ processOptions()
   forceRebuild=false
   buildEnvFile="./buildenv"
   getSourceOnly=false
+  generatePax=false
+  generateSymLink=false
   depsPath="$HOME/zopen/prod|$HOME/zopen/boot|/usr/bin/zopen/"
   forceUpdateDeps=false
   while [[ $# -gt 0 ]]; do
@@ -254,6 +258,12 @@ processOptions()
         ;;
       "-g" | "--get-source")
         getSourceOnly=true
+        ;;
+      "-gp" | "--generate-pax")
+        generatePax=true
+        ;;
+      "-sym" | "--symlink")
+        generateSymLink=true
         ;;
       "-s" | "--shell")
         startShell=true
@@ -1134,8 +1144,17 @@ install()
     chtag -tc 819 "${ZOPEN_INSTALL_DIR}/test.status"
     echo "$ZOPEN_STATUS" > "${ZOPEN_INSTALL_DIR}/test.status"
 
-    if ! runAndLog "${ZOPEN_PAX_CMD}"; then
-      printError "Could not generate pax \"${paxFileName}\""
+    if $generatePax; then
+      printHeader "Generating pax.Z from ${ZOPEN_INSTALL_DIR}"
+      if ! runAndLog "${ZOPEN_PAX_CMD}"; then
+        printError "Could not generate pax \"${paxFileName}\""
+      fi
+    fi
+    if [ -n "${ZOPEN_LINK_CMD}" ]; then
+      printHeader "Generating symlink from ${linkPath} to ${ZOPEN_INSTALL_DIR}"
+      if ! runAndLog "${ZOPEN_LINK_CMD}"; then
+        printError "Link command failed"
+      fi
     fi
     generateOCI $ZOPEN_NAME
   else
@@ -1226,9 +1245,17 @@ resolveCommands()
     [[ -d ${ZOPEN_ROOT}/install ]] || mkdir -p ${ZOPEN_ROOT}/install
     paxFileName="${ZOPEN_ROOT}/install/${ZOPEN_NAME}.${LOG_PFX}.zos.pax.Z"
     export ZOPEN_PAX_CMD="pax -w -z -x pax \"-s#${ZOPEN_INSTALL_DIR}/#${ZOPEN_NAME}.${LOG_PFX}.zos/#\" -f \"${paxFileName}\" \"${ZOPEN_INSTALL_DIR}/\""
+    if $generateSymLink; then
+      PROJECT_NAME="$(echo ${ZOPEN_NAME} | cut -d'-' -f1)"
+      if [ "${PROJECT_NAME}" != "${ZOPEN_NAME}" ]; then
+        linkPath="$(dirname ${ZOPEN_INSTALL_DIR})/${PROJECT_NAME}"
+        export ZOPEN_LINK_CMD="if [ -h ${linkPath} ]; then rm ${linkPath}; fi && ln -s ${ZOPEN_INSTALL_DIR} ${linkPath}"
+      fi
+    fi
   else
     unset ZOPEN_INSTALL_CMD
     unset ZOPEN_PAX_CMD
+    unset ZOPEN_LINK_CMD
   fi
 
   if [ "${ZOPEN_CLEAN}x" != "skipx" ] && [ ! -z "$(command -v ${ZOPEN_CLEAN})" ]; then

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -186,7 +186,7 @@ printSyntax()
   echo "  -f|--force-rebuild: forces a rebuild, including running bootstrap and configure again"
   echo "  -g|--get-source: get the source and apply patch without building"
   echo "  -gp|--generate-pax: generate a pax.Z file based on the install contents"
-  echo "  -sym|--symlink: generate a symlink from the project name to \${ZOPEN_INSTALL_DIR}"
+  echo "  -nosym|--nosymlink: da not generate a symlink from the project name to \${ZOPEN_INSTALL_DIR}"
   echo "  -s: exec a shell before running configure.  Useful when manually building ports."
   opts=$(printEnvVar)
   echo "${opts}" )>&2
@@ -205,7 +205,7 @@ processOptions()
   buildEnvFile="./buildenv"
   getSourceOnly=false
   generatePax=false
-  generateSymLink=false
+  generateSymLink=true
   depsPath="$HOME/zopen/prod|$HOME/zopen/boot|/usr/bin/zopen/"
   forceUpdateDeps=false
   while [[ $# -gt 0 ]]; do
@@ -262,8 +262,8 @@ processOptions()
       "-gp" | "--generate-pax")
         generatePax=true
         ;;
-      "-sym" | "--symlink")
-        generateSymLink=true
+      "-nosym" | "--nosymlink")
+        generateSymLink=false
         ;;
       "-s" | "--shell")
         startShell=true
@@ -531,6 +531,9 @@ setEnv()
   if $buildInReleaseMode; then
     CFLAGS="${CFLAGS} ${optflags}";
     CXXFLAGS="${CXXFLAGS} ${optflags}";
+  else
+    # In debug mode, do not set linker edit=no option so that we can inspect symbols
+    ZOPEN_LDFLAGSD=""
   fi
 
   if [ "${LDFLAGS}x" = "x" ]; then


### PR DESCRIPTION
* Always generating the pax.Z can consume a lot of space, make it optional through the -gp option
* Create symlinks to the installed directory unless the -nosym option is specified.  Project symlinks are handy if you want to make the install dir usable as a dependency
* Also when `-b debug` mode is specified, does not set the LDFLAGS like edit=no since we want to debug and inspect the symbols
