### PR TITLE
Create .zopen-config file with zopen-init, and also update zopen-build/download to depend on it

### DIFF
--- a/bin/lib/common.inc
+++ b/bin/lib/common.inc
@@ -53,6 +53,7 @@ zopenInitialize()
 {
   defineEnvironment
   defineColors
+  processConfig
 }
 
 printVerbose()
@@ -150,6 +151,13 @@ printElapsedTime()
       printVerbose "$elapsedTimeOutput"
       ;;
   esac
+}
+
+processConfig()
+{
+  if [ -f "$HOME/.zopen-config" ]; then
+    . "$HOME/.zopen-config"
+  fi
 }
 
 zopenInitialize

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -208,6 +208,9 @@ processOptions()
   buildEnvFile="./buildenv"
   getSourceOnly=false
   depsPath="$HOME/zopen/prod|$HOME/zopen/boot|/usr/bin/zopen/"
+  if [ ! -z "$ZOPEN_SEARCH_PATH" ]; then
+    depsPath="$ZOPEN_SEARCH_PATH/prod|$ZOPEN_SEARCH_PATH/boot|$depsPath"
+  fi
   forceUpdateDeps=false
   while [[ $# -gt 0 ]]; do
     case $1 in
@@ -390,25 +393,22 @@ setDepsEnv()
     for path in `echo ${depsPath} | tr '|' '\n'` ; do
       if [ -r "$path/${dep}/.env" ]; then
         depdir="$path/${dep}"
-        printVerbose "Setting up ${depdir} dependency environment"
-        cd "${depdir}" && . ./.env
+        # Avoid double sourcing the .env if we're forcing an update it
+        if ! $forceUpdateDeps; then
+          printVerbose "Setting up ${depdir} dependency environment"
+          cd "${depdir}" && . ./.env
+        fi
         foundDep=true
         break
       fi
     done
     if ! $foundDep || $forceUpdateDeps; then
-      #TODO: remove when git is successfully ported
-      if [ ! $foundDep -a $dep = "git" ]; then
-        printError "git not found, the Rocket Git must be manually downloaded"
-      elif [ $foundDep -a $dep = "git" ]; then
-        printWarning "The z/OS Open tools Git is not fully functional, skipping update"
-        continue
-      fi
       if ! $forceUpdateDeps; then
         printWarning "Dependency $dep not found. Downloading via zopen-download"
       else
         printHeader "Updating dependency $dep. Downloading via zopen-download"
       fi
+      # Use the first path specified in the dependency search list
       path=$(echo ${depsPath} | tr '|' '\n' | head -1)
       printVerbose "Running zopen download -r $dep -d $path"
       if ! zopen download -r $dep -d $path; then

--- a/bin/lib/zopen-download
+++ b/bin/lib/zopen-download
@@ -149,7 +149,11 @@ done
 
 # Main code start here
 args=$*
-downloadDir=$PWD
+if [ ! -z "$ZOPEN_SEARCH_PATH" ]; then
+  downloadDir="$ZOPEN_SEARCH_PATH/prod"
+else
+  downloadDir=$PWD
+fi
 updateOnly=true
 verbose=false
 while [[ $# -gt 0 ]]; do
@@ -228,6 +232,8 @@ fi
 if [ ! -z "${downloadDir}" ] && [ -d "${downloadDir}" ]; then
   cd "${downloadDir}"
 fi
+
+printVerbose "Download directory: ${downloadDir}"
 
 # Parse repositories for zopen framework repos
 foundPort=false

--- a/bin/lib/zopen-init
+++ b/bin/lib/zopen-init
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Initialize zopen
+
+export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
+
+. "${utildir}/common.inc"
+
+printSyntax() 
+{
+  args=$*
+  echo "zopen-init will initialize zopen (create a $HOME/.zopen-config file)" >&2
+}
+
+printHeader "Initialize zopen framework"
+
+echo "Enter the path to your zopen install directory (default: $HOME/zopen)"
+zopen_path=$(getInput)
+
+# If the user did not enter a path, use the default
+if [ -z "$zopen_path" ]; then
+  zopen_path="$HOME/zopen"
+fi
+
+if [ ! -e "$zopen_path/prod" ]; then
+  mkdir -p "$zopen_path/prod"
+fi
+if [ ! -e "$zopen_path/boot" ]; then
+  mkdir -p "$zopen_path/boot"
+fi
+
+# Save the configuration to the file
+echo "export ZOPEN_SEARCH_PATH=$zopen_path" > "$HOME/.zopen-config"
+
+printInfo "Creating config in $HOME/.zopen-config"

--- a/bin/zopen
+++ b/bin/zopen
@@ -52,6 +52,10 @@ while [[ $# -gt 0 ]]; do
       shift
       exec "${bindir}/lib/zopen-update-cacert" $@
       ;;
+    "init")
+      shift
+      exec "${bindir}/lib/zopen-init" $@
+      ;;
     "help" | "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
       printHelp "${args}"
       exit 0


### PR DESCRIPTION
* Creates a $HOME/.zopen-config file via zopen-init (we could potentially call this via zopen-setup as well).
* zopen download has been updated to download and check for installed software based on the $ZOPEN_SEARCH_PATH defined in  `$HOME/.zopen-config`.
* zopen build has been updated to search dependences based on the $ZOPEN_SEARCH_PATH defined  `$HOME/.zopen-config`. 
* Also fixed a bug when zopen build -u is specified and the .env is sourced twice. This result in a linker issue with libraries that export ZOPEN_* envars.
* Also, allow our z/OS Open Tools Git as a dependency now that it is functional
