### PR TITLE
Don't let the ZOPEN_CHECK process become an orphaned process upon early exit

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -111,7 +111,13 @@ cleanupOnExit() {
     rv=$?
     [ -f $TEMP_C_FILE ] && rm -rf $TEMP_C_FILE
     [ -p $TMP_FIFO_PIPE ] && rm -rf $TMP_FIFO_PIPE
+    if [ ! -z "$TEE_PID" ]; then
+      if kill -0 $TEE_PID; then
+        kill -9 $TEE_PID;
+      fi
+    fi
     printElapsedTime info "zopen-build" $fullBuildStartTime
+    trap - EXIT # clear the EXIT trap so that it's not double called
     exit $rv
 }
 
@@ -921,6 +927,7 @@ create_fifo_pipe()
   chtag -tc 819 $TMP_FIFO_PIPE
   touch ${file} && chtag -tc 819 ${file}
   tee ${file} < $TMP_FIFO_PIPE &
+  TEE_PID=$!
 }
 
 

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -112,7 +112,7 @@ cleanupOnExit() {
     [ -f $TEMP_C_FILE ] && rm -rf $TEMP_C_FILE
     [ -p $TMP_FIFO_PIPE ] && rm -rf $TMP_FIFO_PIPE
     if [ ! -z "$TEE_PID" ]; then
-      if kill -0 $TEE_PID; then
+      if kill -0 $TEE_PID 2>/dev/null; then
         kill -9 $TEE_PID;
       fi
     fi


### PR DESCRIPTION
The check process is run in the background, so we should ensure that we kill it if `zopen build` is exited early.