### PR TITLE
Avoid processing files in .env if there are no hardcoded paths + separate setup from environment variables

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -569,7 +569,6 @@ setEnv()
   export LDFLAGS="${LDFLAGS} ${ZOPEN_EXTRA_LDFLAGS}"
   export LIBS="${ZOPEN_EXTRA_LIBS}"
 
-
   if [ "${ZOPEN_NUM_JOBS}x" = "x" ]; then
     ZOPEN_NUM_JOBS=$("${utildir}/numcpus.rexx")
 
@@ -609,7 +608,7 @@ setEnv()
     export ZOPEN_INSTALL="${ZOPEN_INSTALLD}"
   fi
   if [ "${ZOPEN_INSTALL_OPTS}x" = "x" ]; then
-    export ZOPEN_INSTALL_OPTS="${ZOPEN_INSTALL_OPTSD}"
+    export ZOPEN_INSTALL_OPTS="-j${ZOPEN_NUM_JOBS} ${ZOPEN_INSTALL_OPTSD}"
   fi
   if [ "${ZOPEN_CLEAN}x" = "x" ]; then
     export ZOPEN_CLEAN="${ZOPEN_CLEAND}"
@@ -1095,13 +1094,15 @@ check()
 replaceHardcodedPaths()
 {
   printHeader "Replacing hardcoded ${ZOPEN_INSTALL_DIR} path"
+  hasHardcodedPaths=false
   for f in $(find ${ZOPEN_INSTALL_DIR}/ -type f | xargs grep -l "${ZOPEN_INSTALL_DIR}" 2>/dev/null); do
+    hasHardcodedPaths=true
     printVerbose "Processing $f"
     cp $f $f.tmp && sed -e "s#${ZOPEN_INSTALL_DIR}#ZOPEN_INSTALL_ROOT#g" $f.tmp > $f && rm $f.tmp;
   done
 }
 
-createEnv()
+createEnvAndSetup()
 {
   printHeader "Creating ${ZOPEN_INSTALL_DIR}/.env"
   projectName=$(echo $ZOPEN_NAME | cut -d "-" -f 1 | awk '{print toupper($0)}')
@@ -1116,11 +1117,10 @@ export _TAG_REDIR_IN=txt
 export _TAG_REDIR_ERR=txt
 export _TAG_REDIR_OUT=txt
 export ${projectName}_HOME=\${PWD}
-for f in \$(find \$PWD/ -type f | xargs grep -l \"ZOPEN_INSTALL_ROOT\" 2>/dev/null); do
-  if [ \"\$f\" != \"\${PWD}/.env\" ]; then
-    cp \$f \$f.tmp && sed -e \"s#ZOPEN_INSTALL_ROOT#\${PWD}#g\" \$f.tmp  > \$f && rm \$f.tmp;
-  fi
-done
+# Run setup.sh if it hasn't been run yet
+if [ ! -f \"./.installed\" ] && [ -e \"./setup.sh\" ]; then
+  ./setup.sh
+fi
 zz
 
   if [ -d "${ZOPEN_INSTALL_DIR}/bin" ]; then
@@ -1137,6 +1137,22 @@ zz
     append_to_env="$(${ZOPEN_APPEND_TO_ENV})"
     echo "$append_to_env" >> "${ZOPEN_INSTALL_DIR}/.env"
   fi
+
+  # Create setup.sh script
+  cat <<zz >"${ZOPEN_INSTALL_DIR}/setup.sh"
+echo \"Setting up ${projectName}...\"
+touch \"\${PWD}/.installed\"
+zz
+  if $hasHardcodedPaths; then
+  cat <<zz >>"${ZOPEN_INSTALL_DIR}/setup.sh"
+for f in \$(find \$PWD/ -type f | xargs grep -l \"ZOPEN_INSTALL_ROOT\" 2>/dev/null); do
+  if [ \"\$f\" != \"\${PWD}/.env\" ]; then
+    cp \$f \$f.tmp && sed -e \"s#ZOPEN_INSTALL_ROOT#\${PWD}#g\" \$f.tmp  > \$f && rm \$f.tmp;
+  fi
+done
+zz
+  fi
+  chmod 755 "${ZOPEN_INSTALL_DIR}/setup.sh"
 }
 
 createReadme()
@@ -1159,8 +1175,8 @@ install()
     if ! runAndLog "${ZOPEN_INSTALL_CMD} > $TMP_FIFO_PIPE"; then
       printError "Install failed. Log: ${installlog}"
     fi
-    createEnv
     replaceHardcodedPaths
+    createEnvAndSetup
 
     if command -V "zopen_post_install" >/dev/null 2>&1; then
       printVerbose "Running zopen_post_install"


### PR DESCRIPTION
Sourcing .env files can take a while since we have a find command that searches for a token and replaces it with the current install path.  This should not be required if we don't have any hardcoded paths in the project.

Also, we should allow the user to reprocess if they move the install dir, so I am introducing a setup.sh script, which we can expand for other purposes. The current behaviour of .env will remain the same as it will call setup.sh unless it has been installed already.